### PR TITLE
Remove debugging assignment

### DIFF
--- a/src/util/rbs_allocator.c
+++ b/src/util/rbs_allocator.c
@@ -125,10 +125,6 @@ void rbs_allocator_free(rbs_allocator_t *allocator) {
         free(page);
         page = next;
     }
-
-    *allocator = (rbs_allocator_t) {
-        .page = NULL,
-    };
 }
 
 // Allocates `size` bytes from `allocator`, aligned to an `alignment`-byte boundary.


### PR DESCRIPTION
This code was added for easier debugging but it's not needed anymore and would fail memory leak checks.