### PR TITLE
Allocate `rbs_string_t` with allocator

### DIFF
--- a/ext/rbs_extension/rbs_string_bridging.c
+++ b/ext/rbs_extension/rbs_string_bridging.c
@@ -1,7 +1,7 @@
 #include "rbs_string_bridging.h"
 
 rbs_string_t rbs_string_from_ruby_string(VALUE ruby_string) {
-    return rbs_string_shared_new(StringValueCStr(ruby_string), RSTRING_END(ruby_string));
+    return rbs_string_new(StringValueCStr(ruby_string), RSTRING_END(ruby_string));
 }
 
 VALUE rbs_string_to_ruby_string(rbs_string_t *self, rb_encoding *encoding) {

--- a/include/rbs/rbs_string.h
+++ b/include/rbs/rbs_string.h
@@ -8,32 +8,17 @@
 typedef struct {
   const char *start;
   const char *end;
-
-  enum rbs_string_type {
-    /** This string is a constant string, and should not be freed. */
-    RBS_STRING_CONSTANT,
-    /** This is a slice of another string, and should not be freed. */
-    RBS_STRING_SHARED,
-    /** This string owns its memory, and will be freed when the allocator is freed. */
-    RBS_STRING_OWNED,
-  } type;
 } rbs_string_t;
 
 #define RBS_STRING_NULL ((rbs_string_t) { \
     .start = NULL,                        \
     .end = NULL,                          \
-    .type = RBS_STRING_CONSTANT,          \
   })
 
 /**
- * Returns a new `rbs_string_t` struct that points to the given C string without owning it.
+ * Returns a new `rbs_string_t` struct
  */
-rbs_string_t rbs_string_shared_new(const char *start, const char *end);
-
-/**
- * Returns a new `rbs_string_t` struct that owns its memory.
- */
-rbs_string_t rbs_string_owned_new(const char *start, const char *end);
+rbs_string_t rbs_string_new(const char *start, const char *end);
 
 /**
  * Copies a portion of the input string into a new owned string.

--- a/include/rbs/rbs_string.h
+++ b/include/rbs/rbs_string.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdbool.h>
+#include "rbs/util/rbs_allocator.h"
 
 typedef struct {
   const char *start;
@@ -13,7 +14,7 @@ typedef struct {
     RBS_STRING_CONSTANT,
     /** This is a slice of another string, and should not be freed. */
     RBS_STRING_SHARED,
-    /** This string owns its memory, and should be freed using `rbs_string_free`. */
+    /** This string owns its memory, and will be freed when the allocator is freed. */
     RBS_STRING_OWNED,
   } type;
 } rbs_string_t;
@@ -38,31 +39,15 @@ rbs_string_t rbs_string_owned_new(const char *start, const char *end);
  * Copies a portion of the input string into a new owned string.
  * @param start_inset Number of characters to exclude from the start
  * @param length Number of characters to include
- * @return A new owned string that needs to be freed using `rbs_string_free()`.
+ * @return A new owned string that will be freed when the allocator is freed.
  */
-rbs_string_t rbs_string_copy_slice(rbs_string_t *self, size_t start_inset, size_t length);
-
-/**
- * Free the associated memory of the given string if it is owned, otherwise does nothing.
- *
- * @param string The string to free.
- * \public \memberof rbs_string_t
- */
-void rbs_string_free_if_needed(rbs_string_t *self);
-
-/**
- * Free the associated memory of the given string if it is owned, otherwise fails (exits the program).
- *
- * @param string The string to free.
- * \public \memberof rbs_string_t
- */
-void rbs_string_free(rbs_string_t *self);
+rbs_string_t rbs_string_copy_slice(rbs_allocator_t *, rbs_string_t *self, size_t start_inset, size_t length);
 
 /**
  * Drops the leading and trailing whitespace from the given string, in-place.
- * @returns A new owned string that needs to be freed with `rbs_string_free()`
+ * @returns A new owned string that will be freed when the allocator is freed.
  */
-rbs_string_t rbs_string_strip_whitespace(rbs_string_t *self);
+rbs_string_t rbs_string_strip_whitespace(rbs_allocator_t *, rbs_string_t *self);
 
 /**
  * Returns the length of the string.

--- a/include/rbs/rbs_unescape.h
+++ b/include/rbs/rbs_unescape.h
@@ -2,6 +2,8 @@
 #define RBS_RBS_UNESCAPE_H
 
 #include <stddef.h>
+#include "rbs/util/rbs_allocator.h"
+#include "rbs/rbs_string.h"
 
 /**
  * Receives `parserstate` and `range`, which represents a string token or symbol token, and returns a string VALUE.
@@ -14,8 +16,8 @@
  *    :"baz\\t"   | baz\t
  *    :'baz'      | baz
  *
- * @returns A new owned string that needs to be freed with `rbs_string_free()`
+ * @returns A new owned string that will be freed when the allocator is freed.
  * */
-rbs_string_t rbs_unquote_string(rbs_string_t input);
+rbs_string_t rbs_unquote_string(rbs_allocator_t *, rbs_string_t input);
 
 #endif // RBS_RBS_UNESCAPE_H

--- a/src/ast.c
+++ b/src/ast.c
@@ -1279,7 +1279,7 @@ void rbs_node_destroy(rbs_node_t *any_node) {
     case RBS_AST_ANNOTATION: {
         rbs_ast_annotation_t *node = (rbs_ast_annotation_t *)any_node;
 
-        rbs_string_free_if_needed(&node->string);
+        // string is a string, so it will be freed when the allocator is freed.
         break;
     }
 #line 202 "prism/templates/src/ast.c.erb"
@@ -1290,7 +1290,7 @@ void rbs_node_destroy(rbs_node_t *any_node) {
     case RBS_AST_COMMENT: {
         rbs_ast_comment_t *node = (rbs_ast_comment_t *)any_node;
 
-        rbs_string_free_if_needed(&node->string);
+        // string is a string, so it will be freed when the allocator is freed.
         break;
     }
 #line 202 "prism/templates/src/ast.c.erb"
@@ -1471,7 +1471,7 @@ void rbs_node_destroy(rbs_node_t *any_node) {
     case RBS_AST_INTEGER: {
         rbs_ast_integer_t *node = (rbs_ast_integer_t *)any_node;
 
-        rbs_string_free_if_needed(&node->string_representation);
+        // string_representation is a string, so it will be freed when the allocator is freed.
         break;
     }
 #line 202 "prism/templates/src/ast.c.erb"
@@ -1698,7 +1698,7 @@ void rbs_node_destroy(rbs_node_t *any_node) {
     case RBS_AST_STRING: {
         rbs_ast_string_t *node = (rbs_ast_string_t *)any_node;
 
-        rbs_string_free_if_needed(&node->string);
+        // string is a string, so it will be freed when the allocator is freed.
         break;
     }
 #line 202 "prism/templates/src/ast.c.erb"

--- a/src/ast.c
+++ b/src/ast.c
@@ -1279,7 +1279,7 @@ void rbs_node_destroy(rbs_node_t *any_node) {
     case RBS_AST_ANNOTATION: {
         rbs_ast_annotation_t *node = (rbs_ast_annotation_t *)any_node;
 
-        // string is a string, so it will be freed when the allocator is freed.
+        // node->string is a `rbs_string_t` that will be freed by the arena allocator.
         break;
     }
 #line 202 "prism/templates/src/ast.c.erb"
@@ -1290,7 +1290,7 @@ void rbs_node_destroy(rbs_node_t *any_node) {
     case RBS_AST_COMMENT: {
         rbs_ast_comment_t *node = (rbs_ast_comment_t *)any_node;
 
-        // string is a string, so it will be freed when the allocator is freed.
+        // node->string is a `rbs_string_t` that will be freed by the arena allocator.
         break;
     }
 #line 202 "prism/templates/src/ast.c.erb"
@@ -1471,7 +1471,7 @@ void rbs_node_destroy(rbs_node_t *any_node) {
     case RBS_AST_INTEGER: {
         rbs_ast_integer_t *node = (rbs_ast_integer_t *)any_node;
 
-        // string_representation is a string, so it will be freed when the allocator is freed.
+        // node->string_representation is a `rbs_string_t` that will be freed by the arena allocator.
         break;
     }
 #line 202 "prism/templates/src/ast.c.erb"
@@ -1698,7 +1698,7 @@ void rbs_node_destroy(rbs_node_t *any_node) {
     case RBS_AST_STRING: {
         rbs_ast_string_t *node = (rbs_ast_string_t *)any_node;
 
-        // string is a string, so it will be freed when the allocator is freed.
+        // node->string is a `rbs_string_t` that will be freed by the arena allocator.
         break;
     }
 #line 202 "prism/templates/src/ast.c.erb"

--- a/src/lexstate.c
+++ b/src/lexstate.c
@@ -110,11 +110,10 @@ unsigned int peek(lexstate *state) {
     state->last_char = '\0';
     return 0;
   } else {
-    rbs_string_t str = {
-      .start = state->string.start + state->current.byte_pos,
-      .end = state->string.end,
-      .type = RBS_STRING_SHARED,
-    };
+    rbs_string_t str = rbs_string_new(
+      state->string.start + state->current.byte_pos,
+      state->string.end
+    );
     unsigned int c = utf8_to_codepoint(str);
     state->last_char = c;
     return c;

--- a/src/parser.c
+++ b/src/parser.c
@@ -326,7 +326,7 @@ static bool parse_function_param(parserstate *state, rbs_types_function_param_t 
       return false;
     }
 
-    rbs_string_t unquoted_str = rbs_unquote_string(rbs_parser_peek_current_token(state));
+    rbs_string_t unquoted_str = rbs_unquote_string(&state->allocator, rbs_parser_peek_current_token(state));
     rbs_location_t *symbolLoc = rbs_location_current_token(state);
     rbs_constant_id_t constant_id = rbs_constant_pool_insert_string(&state->constant_pool, unquoted_str);
     rbs_ast_symbol_t *name = rbs_ast_symbol_new(&state->allocator, symbolLoc, &state->constant_pool, constant_id);
@@ -924,13 +924,11 @@ static bool parse_symbol(parserstate *state, rbs_location_t *location, rbs_types
     rbs_location_t *symbolLoc = rbs_location_current_token(state);
     rbs_string_t current_token = rbs_parser_peek_current_token(state);
 
-    rbs_string_t symbol = rbs_string_copy_slice(&current_token, offset_bytes, rbs_string_len(current_token) - offset_bytes);
+    rbs_string_t symbol = rbs_string_copy_slice(&state->allocator, &current_token, offset_bytes, rbs_string_len(current_token) - offset_bytes);
 
-    rbs_string_t unquoted_symbol = rbs_unquote_string(symbol);
-    rbs_string_free(&symbol);
+    rbs_string_t unquoted_symbol = rbs_unquote_string(&state->allocator, symbol);
 
     rbs_constant_id_t constant_id = rbs_constant_pool_insert_string(&state->constant_pool, unquoted_symbol);
-    // rbs_string_free(&unquoted_symbol);
 
     literal = rbs_ast_symbol_new(&state->allocator, symbolLoc, &state->constant_pool, constant_id);
     break;
@@ -1110,7 +1108,7 @@ static bool parse_simple(parserstate *state, rbs_node_t **type) {
     rbs_location_t *loc = rbs_location_current_token(state);
 
     rbs_string_t string = rbs_parser_peek_current_token(state);
-    rbs_string_t stripped_string = rbs_string_strip_whitespace(&string);
+    rbs_string_t stripped_string = rbs_string_strip_whitespace(&state->allocator, &string);
 
     rbs_node_t *literal = (rbs_node_t *) rbs_ast_integer_new(&state->allocator, loc, stripped_string);
     *type = (rbs_node_t *) rbs_types_literal_new(&state->allocator, loc, literal);
@@ -1130,7 +1128,7 @@ static bool parse_simple(parserstate *state, rbs_node_t **type) {
   case tDQSTRING: {
     rbs_location_t *loc = rbs_location_current_token(state);
 
-    rbs_string_t unquoted_str = rbs_unquote_string(rbs_parser_peek_current_token(state));
+    rbs_string_t unquoted_str = rbs_unquote_string(&state->allocator, rbs_parser_peek_current_token(state));
     rbs_node_t *literal = (rbs_node_t *) rbs_ast_string_new(&state->allocator, loc, unquoted_str);
     *type = (rbs_node_t *) rbs_types_literal_new(&state->allocator, loc, literal);
     return true;
@@ -1591,13 +1589,13 @@ static bool parse_annotation(parserstate *state, rbs_ast_annotation_t **annotati
   size_t total_offset = offset_bytes + open_bytes;
 
   rbs_string_t annotation_str = rbs_string_copy_slice(
+    &state->allocator,
     &current_token,
     total_offset,
     rbs_string_len(current_token) - total_offset - close_bytes
   );
 
-  rbs_string_t stripped_annotation_str = rbs_string_strip_whitespace(&annotation_str);
-  rbs_string_free(&annotation_str);
+  rbs_string_t stripped_annotation_str = rbs_string_strip_whitespace(&state->allocator, &annotation_str);
 
   *annotation = rbs_ast_annotation_new(&state->allocator, rbs_location_new(&state->allocator, rg), stripped_annotation_str);
   return true;
@@ -1675,7 +1673,7 @@ static bool parse_method_name(parserstate *state, range *range, rbs_ast_symbol_t
   }
   case tQIDENT: {
     rbs_string_t string = rbs_parser_peek_current_token(state);
-    rbs_string_t unquoted_str = rbs_unquote_string(string);
+    rbs_string_t unquoted_str = rbs_unquote_string(&state->allocator, string);
     rbs_constant_id_t constant_id = rbs_constant_pool_insert_string(&state->constant_pool, unquoted_str);
     rbs_location_t *symbolLoc = rbs_location_current_token(state);
     *symbol = rbs_ast_symbol_new(&state->allocator, symbolLoc, &state->constant_pool, constant_id);

--- a/src/parser.c
+++ b/src/parser.c
@@ -113,7 +113,7 @@ static rbs_string_t rbs_parser_peek_current_token(parserstate *state) {
   const char *start = state->lexstate->string.start + rg.start.byte_pos;
   size_t length = rg.end.byte_pos - rg.start.byte_pos;
 
-  return rbs_string_shared_new(start, start + length);
+  return rbs_string_new(start, start + length);
 }
 
 static rbs_constant_id_t rbs_constant_pool_insert_string(rbs_constant_pool_t *self, rbs_string_t string) {
@@ -1552,11 +1552,10 @@ static bool parse_annotation(parserstate *state, rbs_ast_annotation_t **annotati
     state->lexstate->encoding->char_width((const uint8_t *) "%", (size_t) 1) +
     state->lexstate->encoding->char_width((const uint8_t *) "a", (size_t) 1);
 
-  rbs_string_t str = {
-    .start = state->lexstate->string.start + rg.start.byte_pos + offset_bytes,
-    .end = state->lexstate->string.end,
-    .type = RBS_STRING_SHARED,
-  };
+  rbs_string_t str = rbs_string_new(
+    state->lexstate->string.start + rg.start.byte_pos + offset_bytes,
+    state->lexstate->string.end
+  );
   unsigned int open_char = utf8_to_codepoint(str);
 
   unsigned int close_char;

--- a/src/parserstate.c
+++ b/src/parserstate.c
@@ -186,11 +186,10 @@ static rbs_ast_comment_t *parse_comment_lines(parserstate *state, comment *com) 
     const char *comment_start = state->lexstate->string.start + tok.range.start.byte_pos + hash_bytes;
     size_t comment_bytes = RANGE_BYTES(tok.range) - hash_bytes;
 
-    rbs_string_t str = {
-      .start = comment_start,
-      .end = state->lexstate->string.end,
-      .type = RBS_STRING_SHARED,
-    };
+    rbs_string_t str = rbs_string_new(
+      comment_start,
+      state->lexstate->string.end
+    );
     unsigned char c = utf8_to_codepoint(str);
 
     if (c == ' ') {

--- a/src/rbs_buffer.c
+++ b/src/rbs_buffer.c
@@ -56,7 +56,7 @@ void rbs_buffer_append_string(rbs_buffer_t *buffer, const char *value, size_t le
 }
 
 rbs_string_t rbs_buffer_to_string(rbs_buffer_t *buffer) {
-    return rbs_string_shared_new(buffer->value, buffer->value + buffer->length);
+    return rbs_string_new(buffer->value, buffer->value + buffer->length);
 }
 
 void rbs_buffer_free(rbs_buffer_t *buffer) {

--- a/src/rbs_string.c
+++ b/src/rbs_string.c
@@ -5,19 +5,10 @@
 #include <stdio.h>
 #include <ctype.h>
 
-rbs_string_t rbs_string_shared_new(const char *start, const char *end) {
+rbs_string_t rbs_string_new(const char *start, const char *end) {
     return (rbs_string_t) {
         .start = start,
         .end = end,
-        .type = RBS_STRING_SHARED,
-    };
-}
-
-rbs_string_t rbs_string_owned_new(const char *start, const char *end) {
-    return (rbs_string_t) {
-        .start = start,
-        .end = end,
-        .type = RBS_STRING_OWNED,
     };
 }
 
@@ -26,7 +17,7 @@ rbs_string_t rbs_string_copy_slice(rbs_allocator_t *allocator, rbs_string_t *sel
     strncpy(buffer, self->start + start_inset, length);
     buffer[length] = '\0';
 
-    return rbs_string_owned_new(buffer, buffer + length);
+    return rbs_string_new(buffer, buffer + length);
 }
 
 rbs_string_t rbs_string_strip_whitespace(rbs_allocator_t *allocator, rbs_string_t *self) {
@@ -36,7 +27,7 @@ rbs_string_t rbs_string_strip_whitespace(rbs_allocator_t *allocator, rbs_string_
     }
 
     if (new_start == self->end) { // Handle empty string case
-        return rbs_string_shared_new(new_start, new_start);
+        return rbs_string_new(new_start, new_start);
     }
 
     const char *new_end = self->end - 1;

--- a/src/rbs_string.c
+++ b/src/rbs_string.c
@@ -21,30 +21,15 @@ rbs_string_t rbs_string_owned_new(const char *start, const char *end) {
     };
 }
 
-rbs_string_t rbs_string_copy_slice(rbs_string_t *self, size_t start_inset, size_t length) {
-    char *buffer = (char *) malloc(length + 1);
+rbs_string_t rbs_string_copy_slice(rbs_allocator_t *allocator, rbs_string_t *self, size_t start_inset, size_t length) {
+    char *buffer = rbs_allocator_calloc(allocator, length + 1, char);
     strncpy(buffer, self->start + start_inset, length);
     buffer[length] = '\0';
 
     return rbs_string_owned_new(buffer, buffer + length);
 }
 
-void rbs_string_free_if_needed(rbs_string_t *self) {
-    if (self->type == RBS_STRING_OWNED) {
-        rbs_string_free(self);
-    }
-}
-
-void rbs_string_free(rbs_string_t *self) {
-    if (self->type != RBS_STRING_OWNED) {
-        fprintf(stderr, "rbs_string_free(%p): not owned\n", self->start);
-        exit(EXIT_FAILURE);
-    }
-
-    free((void *) self->start);
-}
-
-rbs_string_t rbs_string_strip_whitespace(rbs_string_t *self) {
+rbs_string_t rbs_string_strip_whitespace(rbs_allocator_t *allocator, rbs_string_t *self) {
     const char *new_start = self->start;
     while (isspace(*new_start) && new_start < self->end) {
         new_start++;
@@ -59,7 +44,7 @@ rbs_string_t rbs_string_strip_whitespace(rbs_string_t *self) {
         new_end--;
     }
 
-    return rbs_string_copy_slice(self, new_start - self->start, new_end - new_start + 1);
+    return rbs_string_copy_slice(allocator, self, new_start - self->start, new_end - new_start + 1);
 }
 
 size_t rbs_string_len(const rbs_string_t self) {

--- a/src/rbs_unescape.c
+++ b/src/rbs_unescape.c
@@ -1,6 +1,5 @@
 #include "rbs/encoding.h"
 #include "rbs/rbs_unescape.h"
-#include "rbs/rbs_string.h"
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -44,13 +43,13 @@ static int octal_to_int(const char* octal, int length) {
     return result;
 }
 
-rbs_string_t unescape_string(const rbs_string_t string, bool is_double_quote) {
+rbs_string_t unescape_string(rbs_allocator_t *allocator, rbs_string_t string, bool is_double_quote) {
     if (!string.start) return RBS_STRING_NULL;
 
     size_t len = string.end - string.start;
     const char* input = string.start;
 
-    char* output = malloc(len + 1);
+    char* output = rbs_allocator_calloc(allocator, len + 1, char);
     if (!output) return RBS_STRING_NULL;
 
     size_t i = 0, j = 0;
@@ -107,7 +106,7 @@ rbs_string_t unescape_string(const rbs_string_t string, bool is_double_quote) {
     return rbs_string_owned_new(output, output + j);
 }
 
-rbs_string_t rbs_unquote_string(rbs_string_t input) {
+rbs_string_t rbs_unquote_string(rbs_allocator_t *allocator, rbs_string_t input) {
     unsigned int first_char = utf8_to_codepoint(input);
     size_t byte_length = rbs_string_len(input);
 
@@ -118,6 +117,6 @@ rbs_string_t rbs_unquote_string(rbs_string_t input) {
       byte_length -= 2 * bs;
     }
 
-    rbs_string_t string = rbs_string_copy_slice(&input, start_offset, byte_length);
-    return unescape_string(string, first_char == '"');
+    rbs_string_t string = rbs_string_copy_slice(allocator, &input, start_offset, byte_length);
+    return unescape_string(allocator, string, first_char == '"');
 }

--- a/src/rbs_unescape.c
+++ b/src/rbs_unescape.c
@@ -103,7 +103,7 @@ rbs_string_t unescape_string(rbs_allocator_t *allocator, rbs_string_t string, bo
         }
     }
     output[j] = '\0';
-    return rbs_string_owned_new(output, output + j);
+    return rbs_string_new(output, output + j);
 }
 
 rbs_string_t rbs_unquote_string(rbs_allocator_t *allocator, rbs_string_t input) {

--- a/templates/src/ast.c.erb
+++ b/templates/src/ast.c.erb
@@ -206,7 +206,7 @@ void rbs_node_destroy(rbs_node_t *any_node) {
         <%- node.fields.each do |field| -%>
         <%- case field.c_type -%>
         <%- when "rbs_string" -%>
-        rbs_string_free_if_needed(&node-><%= field.c_name %>);
+        // <%= field.c_name %> is a string, so it will be freed when the allocator is freed.
         <%- when "rbs_node_list" -%>
         rbs_node_list_free(node-><%= field.c_name %>);
         <%- when "rbs_hash" -%>

--- a/templates/src/ast.c.erb
+++ b/templates/src/ast.c.erb
@@ -206,7 +206,7 @@ void rbs_node_destroy(rbs_node_t *any_node) {
         <%- node.fields.each do |field| -%>
         <%- case field.c_type -%>
         <%- when "rbs_string" -%>
-        // <%= field.c_name %> is a string, so it will be freed when the allocator is freed.
+        // node-><%= field.c_name %> is a `rbs_string_t` that will be freed by the arena allocator.
         <%- when "rbs_node_list" -%>
         rbs_node_list_free(node-><%= field.c_name %>);
         <%- when "rbs_hash" -%>


### PR DESCRIPTION
1. `rbs_string_t` owned by the parser is now allocated by the allocator
2. Because of 1, we don't need to care if a string is owned or shared anymore, so a lot of associated code can now go away