### PR TITLE
Add `rbs_allocator_alloc_many` to avoid unnecessary 0 initialization on memory

### DIFF
--- a/include/rbs/util/rbs_allocator.h
+++ b/include/rbs/util/rbs_allocator.h
@@ -21,12 +21,15 @@ typedef struct rbs_allocator {
 
 void rbs_allocator_init(rbs_allocator_t *);
 void rbs_allocator_free(rbs_allocator_t *);
-void *rbs_allocator_malloc_impl(rbs_allocator_t *, /*    1    */ size_t size, size_t alignment);
-void *rbs_allocator_calloc_impl(rbs_allocator_t *, size_t count, size_t size, size_t alignment);
-void *rbs_allocator_realloc_impl(rbs_allocator_t *, void *ptr, size_t old_size, size_t new_size, size_t alignment);
+void *rbs_allocator_malloc_impl      (rbs_allocator_t *, /*    1    */ size_t size, size_t alignment);
+void *rbs_allocator_malloc_many_impl (rbs_allocator_t *, size_t count, size_t size, size_t alignment);
+void *rbs_allocator_calloc_impl      (rbs_allocator_t *, size_t count, size_t size, size_t alignment);
 
-#define rbs_allocator_alloc(allocator, type)         ((type *) rbs_allocator_malloc_impl((allocator),          sizeof(type), alignof(type)))
-#define rbs_allocator_calloc(allocator, count, type) ((type *) rbs_allocator_calloc_impl((allocator), (count), sizeof(type), alignof(type)))
+void *rbs_allocator_realloc_impl     (rbs_allocator_t *, void *ptr, size_t old_size, size_t new_size, size_t alignment);
+
+#define rbs_allocator_alloc(allocator, type)             ((type *) rbs_allocator_malloc_impl((allocator), sizeof(type), alignof(type)))
+#define rbs_allocator_alloc_many(allocator, count, type) ((type *) rbs_allocator_malloc_many_impl((allocator), (count), sizeof(type), alignof(type)))
+#define rbs_allocator_calloc(allocator, count, type)     ((type *) rbs_allocator_calloc_impl((allocator), (count), sizeof(type), alignof(type)))
 #define rbs_allocator_realloc(allocator, ptr, old_size, new_size, type) ((type *) rbs_allocator_realloc_impl((allocator), (ptr), (old_size), (new_size), alignof(type)))
 
 void rbs__init_arena_allocator(void);

--- a/include/rbs/util/rbs_allocator.h
+++ b/include/rbs/util/rbs_allocator.h
@@ -27,8 +27,13 @@ void *rbs_allocator_calloc_impl      (rbs_allocator_t *, size_t count, size_t si
 
 void *rbs_allocator_realloc_impl     (rbs_allocator_t *, void *ptr, size_t old_size, size_t new_size, size_t alignment);
 
+// Use this when allocating memory for a single instance of a type.
 #define rbs_allocator_alloc(allocator, type)             ((type *) rbs_allocator_malloc_impl((allocator), sizeof(type), alignof(type)))
+// Use this when allocating memory that will be immediately written to in full.
+// Such as allocating strings
 #define rbs_allocator_alloc_many(allocator, count, type) ((type *) rbs_allocator_malloc_many_impl((allocator), (count), sizeof(type), alignof(type)))
+// Use this when allocating memory that will NOT be immediately written to in full.
+// Such as allocating buffers
 #define rbs_allocator_calloc(allocator, count, type)     ((type *) rbs_allocator_calloc_impl((allocator), (count), sizeof(type), alignof(type)))
 #define rbs_allocator_realloc(allocator, ptr, old_size, new_size, type) ((type *) rbs_allocator_realloc_impl((allocator), (ptr), (old_size), (new_size), alignof(type)))
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -131,7 +131,7 @@ void set_error(parserstate *state, token tok, bool syntax_error, const char *fmt
   int length = vsnprintf(NULL, 0, fmt, args);
   va_end(args);
 
-  char *message = rbs_allocator_calloc(&state->allocator, length + 1, char);
+  char *message = rbs_allocator_alloc_many(&state->allocator, length + 1, char);
 
   va_start(args, fmt);
   vsnprintf(message, length + 1, fmt, args);

--- a/src/rbs_string.c
+++ b/src/rbs_string.c
@@ -13,7 +13,7 @@ rbs_string_t rbs_string_new(const char *start, const char *end) {
 }
 
 rbs_string_t rbs_string_copy_slice(rbs_allocator_t *allocator, rbs_string_t *self, size_t start_inset, size_t length) {
-    char *buffer = rbs_allocator_calloc(allocator, length + 1, char);
+    char *buffer = rbs_allocator_alloc_many(allocator, length + 1, char);
     strncpy(buffer, self->start + start_inset, length);
     buffer[length] = '\0';
 

--- a/src/rbs_unescape.c
+++ b/src/rbs_unescape.c
@@ -49,7 +49,7 @@ rbs_string_t unescape_string(rbs_allocator_t *allocator, rbs_string_t string, bo
     size_t len = string.end - string.start;
     const char* input = string.start;
 
-    char* output = rbs_allocator_calloc(allocator, len + 1, char);
+    char* output = rbs_allocator_alloc_many(allocator, len + 1, char);
     if (!output) return RBS_STRING_NULL;
 
     size_t i = 0, j = 0;

--- a/src/util/rbs_allocator.c
+++ b/src/util/rbs_allocator.c
@@ -183,8 +183,12 @@ void *rbs_allocator_malloc_impl(rbs_allocator_t *allocator, size_t size, size_t 
 // Note: This will eagerly fill with zeroes, unlike `calloc()` which can map a page in a page to be zeroed lazily.
 //       It's assumed that callers to this function will immediately write to the allocated memory, anyway.
 void *rbs_allocator_calloc_impl(rbs_allocator_t *allocator, size_t count, size_t size, size_t alignment) {
-    void *p = rbs_allocator_malloc_impl(allocator, count * size, alignment);
+    void *p = rbs_allocator_malloc_many_impl(allocator, count, size, alignment);
     memset(p, 0, count * size);
     return p;
 }
 
+// Similar to `rbs_allocator_malloc_impl()`, but allocates `count` instances of `size` bytes, aligned to an `alignment`-byte boundary.
+void *rbs_allocator_malloc_many_impl(rbs_allocator_t *allocator, size_t count, size_t size, size_t alignment) {
+    return rbs_allocator_malloc_impl(allocator, count * size, alignment);
+}


### PR DESCRIPTION
Suggested in https://github.com/Shopify/rbs/pull/14#discussion_r1991493853

Most of the time, when we allocate multiple instances of a type with `rbs_allocator_calloc`, we're immediately writing to the allocated memory anyway. So there's no reason to zero-initialize the memory.

This change reduces the number of calls to `memset()` in the runtime.