### PR TITLE
Fix code that triggers warnings when compiled with Sorbet

### DIFF
--- a/include/rbs/rbs_location.h
+++ b/include/rbs/rbs_location.h
@@ -12,7 +12,7 @@ typedef struct rbs_location {
     rbs_loc_children *children;
 } rbs_location_t;
 
-void rbs_loc_alloc_children(rbs_allocator_t *, rbs_location_t *loc, int size);
+void rbs_loc_alloc_children(rbs_allocator_t *, rbs_location_t *loc, size_t capacity);
 void rbs_loc_add_required_child(rbs_location_t *loc, rbs_constant_id_t name, range r);
 void rbs_loc_add_optional_child(rbs_location_t *loc, rbs_constant_id_t name, range r);
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -1277,9 +1277,6 @@ void rbs_node_destroy(rbs_node_t *any_node) {
     switch (any_node->type) {
 #line 202 "prism/templates/src/ast.c.erb"
     case RBS_AST_ANNOTATION: {
-        rbs_ast_annotation_t *node = (rbs_ast_annotation_t *)any_node;
-
-        // node->string is a `rbs_string_t` that will be freed by the arena allocator.
         break;
     }
 #line 202 "prism/templates/src/ast.c.erb"
@@ -1288,9 +1285,6 @@ void rbs_node_destroy(rbs_node_t *any_node) {
     }
 #line 202 "prism/templates/src/ast.c.erb"
     case RBS_AST_COMMENT: {
-        rbs_ast_comment_t *node = (rbs_ast_comment_t *)any_node;
-
-        // node->string is a `rbs_string_t` that will be freed by the arena allocator.
         break;
     }
 #line 202 "prism/templates/src/ast.c.erb"
@@ -1469,9 +1463,6 @@ void rbs_node_destroy(rbs_node_t *any_node) {
     }
 #line 202 "prism/templates/src/ast.c.erb"
     case RBS_AST_INTEGER: {
-        rbs_ast_integer_t *node = (rbs_ast_integer_t *)any_node;
-
-        // node->string_representation is a `rbs_string_t` that will be freed by the arena allocator.
         break;
     }
 #line 202 "prism/templates/src/ast.c.erb"
@@ -1696,9 +1687,6 @@ void rbs_node_destroy(rbs_node_t *any_node) {
     }
 #line 202 "prism/templates/src/ast.c.erb"
     case RBS_AST_STRING: {
-        rbs_ast_string_t *node = (rbs_ast_string_t *)any_node;
-
-        // node->string is a `rbs_string_t` that will be freed by the arena allocator.
         break;
     }
 #line 202 "prism/templates/src/ast.c.erb"

--- a/src/rbs_location.c
+++ b/src/rbs_location.c
@@ -4,9 +4,8 @@
 
 #define RBS_LOC_CHILDREN_SIZE(cap) (sizeof(rbs_loc_children) + sizeof(rbs_loc_entry) * ((cap) - 1))
 
-void rbs_loc_alloc_children(rbs_allocator_t *allocator, rbs_location_t *loc, int capacity) {
-  size_t max = sizeof(rbs_loc_entry_bitmap) * 8;
-  assert(capacity <= max && "Capacity is too large");
+void rbs_loc_alloc_children(rbs_allocator_t *allocator, rbs_location_t *loc, size_t capacity) {
+  assert(capacity <= sizeof(rbs_loc_entry_bitmap) * 8 && "Capacity is too large");
 
   loc->children = rbs_allocator_malloc_impl(allocator, RBS_LOC_CHILDREN_SIZE(capacity), alignof(rbs_loc_children));
 
@@ -18,7 +17,7 @@ void rbs_loc_alloc_children(rbs_allocator_t *allocator, rbs_location_t *loc, int
 void rbs_loc_add_optional_child(rbs_location_t *loc, rbs_constant_id_t name, range r) {
   assert(loc->children != NULL && "All children should have been pre-allocated with rbs_loc_alloc_children()");
   assert((loc->children->len + 1 <= loc->children->cap) && "Not enough space was pre-allocated for the children.");
-  
+
   unsigned short i = loc->children->len++;
   loc->children->entries[i].name = name;
   loc->children->entries[i].rg = (rbs_loc_range) { r.start.char_pos, r.end.char_pos };

--- a/templates/src/ast.c.erb
+++ b/templates/src/ast.c.erb
@@ -205,8 +205,6 @@ void rbs_node_destroy(rbs_node_t *any_node) {
 
         <%- node.fields.each do |field| -%>
         <%- case field.c_type -%>
-        <%- when "rbs_string" -%>
-        // node-><%= field.c_name %> is a `rbs_string_t` that will be freed by the arena allocator.
         <%- when "rbs_node_list" -%>
         rbs_node_list_free(node-><%= field.c_name %>);
         <%- when "rbs_hash" -%>

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -55,7 +55,7 @@ module RBS
       end
 
       def needs_to_be_freed?
-        !["VALUE", "bool"].include?(@c_type)
+        !["VALUE", "bool", "rbs_string"].include?(@c_type)
       end
     end
 


### PR DESCRIPTION
I was testing the latest `c-api` commit against Sorbet, and I found a few warnings that need to be addressed:

### Avoid declaring unused `node` variables in `rbs_node_destroy`'s template

Such declarations will fail Sorbet's compiler:

```
prism/templates/src/ast.c.erb:203:31: error: unused variable 'node' [-Werror,-Wunused-variable]
        rbs_ast_annotation_t *node = (rbs_ast_annotation_t *)any_node;
                              ^
prism/templates/src/ast.c.erb:203:28: error: unused variable 'node' [-Werror,-Wunused-variable]
        rbs_ast_comment_t *node = (rbs_ast_comment_t *)any_node;
                           ^
prism/templates/src/ast.c.erb:203:28: error: unused variable 'node' [-Werror,-Wunused-variable]
        rbs_ast_integer_t *node = (rbs_ast_integer_t *)any_node;
                           ^
prism/templates/src/ast.c.erb:203:27: error: unused variable 'node' [-Werror,-Wunused-variable]
        rbs_ast_string_t *node = (rbs_ast_string_t *)any_node;
                          ^
```

### Use `size_t` instead of `int` for `capacity` in `rbs_loc_alloc_children`

This fixes a warning about comparing `int` and `size_t` in `rbs_loc_alloc_children`'s assertion.

### Avoid declaring the `max` variable that's just used in assertions

When the `assert` is stripped out, the variable becomes unused and triggers a warning.

```
external/rbs_parser/src/rbs_location.c:8:10: warning: unused variable 'max' [-Wunused-variable]
  size_t max = sizeof(rbs_loc_entry_bitmap) * 8;
         ^
```