### PR TITLE
Rename lexer struct, param, and functions

### DIFF
--- a/ext/rbs_extension/main.c
+++ b/ext/rbs_extension/main.c
@@ -291,7 +291,7 @@ static VALUE rbsparser_lex(VALUE self, VALUE buffer, VALUE end_pos) {
   VALUE results = rb_ary_new();
   rbs_token_t token = NullToken;
   while (token.type != pEOF) {
-    token = rbsparser_next_token(lexer);
+    token = rbs_lexer_next_token(lexer);
     VALUE type = ID2SYM(rb_intern(rbs_token_type_str(token.type)));
     VALUE location = rbs_new_location(buffer, token.range);
     VALUE pair = rb_ary_new3(2, type, location);

--- a/ext/rbs_extension/main.c
+++ b/ext/rbs_extension/main.c
@@ -129,7 +129,7 @@ static VALUE parse_type_try(VALUE a) {
   return ruby_ast;
 }
 
-static lexstate *alloc_lexer_from_buffer(rbs_allocator_t *allocator, VALUE string, rb_encoding *encoding, int start_pos, int end_pos) {
+static rbs_lexer_t *alloc_lexer_from_buffer(rbs_allocator_t *allocator, VALUE string, rb_encoding *encoding, int start_pos, int end_pos) {
   if (start_pos < 0 || end_pos < 0) {
     rb_raise(rb_eArgError, "negative position range: %d...%d", start_pos, end_pos);
   }
@@ -286,7 +286,7 @@ static VALUE rbsparser_lex(VALUE self, VALUE buffer, VALUE end_pos) {
 
   rbs_allocator_t allocator;
   rbs_allocator_init(&allocator);
-  lexstate *lexer = alloc_lexer_from_buffer(&allocator, string, encoding, 0, FIX2INT(end_pos));
+  rbs_lexer_t *lexer = alloc_lexer_from_buffer(&allocator, string, encoding, 0, FIX2INT(end_pos));
 
   VALUE results = rb_ary_new();
   rbs_token_t token = NullToken;

--- a/include/rbs/lexer.h
+++ b/include/rbs/lexer.h
@@ -176,7 +176,7 @@ rbs_token_t rbs_next_token(rbs_lexer_t *lexer, enum RBSTokenType type);
  * */
 rbs_token_t rbs_next_eof_token(rbs_lexer_t *lexer);
 
-rbs_token_t rbsparser_next_token(rbs_lexer_t *lexer);
+rbs_token_t rbs_lexer_next_token(rbs_lexer_t *lexer);
 
 void rbs_print_token(rbs_token_t tok);
 

--- a/include/rbs/lexer.h
+++ b/include/rbs/lexer.h
@@ -140,7 +140,7 @@ extern rbs_token_t NullToken;
 extern rbs_position_t NullPosition;
 extern rbs_range_t NULL_RANGE;
 
-char *rbs_peek_token(rbs_lexer_t *state, rbs_token_t tok);
+char *rbs_peek_token(rbs_lexer_t *lexer, rbs_token_t tok);
 int rbs_token_chars(rbs_token_t tok);
 int rbs_token_bytes(rbs_token_t tok);
 
@@ -154,29 +154,29 @@ const char *rbs_token_type_str(enum RBSTokenType type);
 /**
  * Read next character.
  * */
-unsigned int rbs_peek(rbs_lexer_t *state);
+unsigned int rbs_peek(rbs_lexer_t *lexer);
 
 /**
  * Skip one character.
  * */
-void rbs_skip(rbs_lexer_t *state);
+void rbs_skip(rbs_lexer_t *lexer);
 
 /**
  * Skip n characters.
  * */
-void rbs_skipn(rbs_lexer_t *state, size_t size);
+void rbs_skipn(rbs_lexer_t *lexer, size_t size);
 
 /**
  * Return new rbs_token_t with given type.
  * */
-rbs_token_t rbs_next_token(rbs_lexer_t *state, enum RBSTokenType type);
+rbs_token_t rbs_next_token(rbs_lexer_t *lexer, enum RBSTokenType type);
 
 /**
  * Return new rbs_token_t with EOF type.
  * */
-rbs_token_t rbs_next_eof_token(rbs_lexer_t *state);
+rbs_token_t rbs_next_eof_token(rbs_lexer_t *lexer);
 
-rbs_token_t rbsparser_next_token(rbs_lexer_t *state);
+rbs_token_t rbsparser_next_token(rbs_lexer_t *lexer);
 
 void rbs_print_token(rbs_token_t tok);
 

--- a/include/rbs/lexer.h
+++ b/include/rbs/lexer.h
@@ -134,13 +134,13 @@ typedef struct {
   bool first_token_of_line;       /* This flag is used for tLINECOMMENT */
   unsigned int last_char;         /* Last peeked character */
   const rbs_encoding_t *encoding;
-} lexstate;
+} rbs_lexer_t;
 
 extern rbs_token_t NullToken;
 extern rbs_position_t NullPosition;
 extern rbs_range_t NULL_RANGE;
 
-char *rbs_peek_token(lexstate *state, rbs_token_t tok);
+char *rbs_peek_token(rbs_lexer_t *state, rbs_token_t tok);
 int rbs_token_chars(rbs_token_t tok);
 int rbs_token_bytes(rbs_token_t tok);
 
@@ -154,29 +154,29 @@ const char *rbs_token_type_str(enum RBSTokenType type);
 /**
  * Read next character.
  * */
-unsigned int rbs_peek(lexstate *state);
+unsigned int rbs_peek(rbs_lexer_t *state);
 
 /**
  * Skip one character.
  * */
-void rbs_skip(lexstate *state);
+void rbs_skip(rbs_lexer_t *state);
 
 /**
  * Skip n characters.
  * */
-void rbs_skipn(lexstate *state, size_t size);
+void rbs_skipn(rbs_lexer_t *state, size_t size);
 
 /**
  * Return new rbs_token_t with given type.
  * */
-rbs_token_t rbs_next_token(lexstate *state, enum RBSTokenType type);
+rbs_token_t rbs_next_token(rbs_lexer_t *state, enum RBSTokenType type);
 
 /**
  * Return new rbs_token_t with EOF type.
  * */
-rbs_token_t rbs_next_eof_token(lexstate *state);
+rbs_token_t rbs_next_eof_token(rbs_lexer_t *state);
 
-rbs_token_t rbsparser_next_token(lexstate *state);
+rbs_token_t rbsparser_next_token(rbs_lexer_t *state);
 
 void rbs_print_token(rbs_token_t tok);
 

--- a/include/rbs/parser.h
+++ b/include/rbs/parser.h
@@ -44,7 +44,7 @@ typedef struct rbs_error_t {
  * An RBS parser is a LL(3) parser.
  * */
 typedef struct {
-  lexstate *lexstate;
+  rbs_lexer_t *rbs_lexer_t;
 
   rbs_token_t current_token;
   rbs_token_t next_token;       /* The first lookahead token */
@@ -83,14 +83,14 @@ void rbs_parser_push_typevar_table(rbs_parser_t *parser, bool reset);
 NODISCARD bool rbs_parser_insert_typevar(rbs_parser_t *parser, rbs_constant_id_t id);
 
 /**
- * Allocate new lexstate object.
+ * Allocate new rbs_lexer_t object.
  *
  * ```
  * VALUE string = rb_funcall(buffer, rb_intern("content"), 0);
- * rbs_lexer_new(string, 0, 31)    // New lexstate with buffer content
+ * rbs_lexer_new(string, 0, 31)    // New rbs_lexer_t with buffer content
  * ```
  * */
-lexstate *rbs_lexer_new(rbs_allocator_t *, rbs_string_t string, const rbs_encoding_t *encoding, int start_pos, int end_pos);
+rbs_lexer_t *rbs_lexer_new(rbs_allocator_t *, rbs_string_t string, const rbs_encoding_t *encoding, int start_pos, int end_pos);
 
 /**
  * Allocate new rbs_parser_t object.

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2,7 +2,7 @@
 #line 1 "src/lexer.re"
 #include "rbs/lexer.h"
 
-rbs_token_t rbsparser_next_token(rbs_lexer_t *lexer) {
+rbs_token_t rbs_lexer_next_token(rbs_lexer_t *lexer) {
   rbs_lexer_t backup;
 
   backup = *lexer;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2,8 +2,8 @@
 #line 1 "src/lexer.re"
 #include "rbs/lexer.h"
 
-rbs_token_t rbsparser_next_token(lexstate *state) {
-  lexstate backup;
+rbs_token_t rbsparser_next_token(rbs_lexer_t *state) {
+  rbs_lexer_t backup;
 
   backup = *state;
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2,17 +2,17 @@
 #line 1 "src/lexer.re"
 #include "rbs/lexer.h"
 
-rbs_token_t rbsparser_next_token(rbs_lexer_t *state) {
+rbs_token_t rbsparser_next_token(rbs_lexer_t *lexer) {
   rbs_lexer_t backup;
 
-  backup = *state;
+  backup = *lexer;
 
   
 #line 12 "src/lexer.c"
 {
 	unsigned int yych;
 	unsigned int yyaccept = 0;
-	yych = rbs_peek(state);
+	yych = rbs_peek(lexer);
 	switch (yych) {
 		case 0x00000000: goto yy1;
 		case '\t':
@@ -114,61 +114,61 @@ rbs_token_t rbsparser_next_token(rbs_lexer_t *state) {
 		default: goto yy2;
 	}
 yy1:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 144 "src/lexer.re"
-	{ return rbs_next_eof_token(state); }
+	{ return rbs_next_eof_token(lexer); }
 #line 121 "src/lexer.c"
 yy2:
-	rbs_skip(state);
+	rbs_skip(lexer);
 yy3:
 #line 145 "src/lexer.re"
-	{ return rbs_next_token(state, ErrorToken); }
+	{ return rbs_next_token(lexer, ErrorToken); }
 #line 127 "src/lexer.c"
 yy4:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '\t') goto yy4;
 	if (yych == ' ') goto yy4;
 yy5:
 #line 143 "src/lexer.re"
-	{ return rbs_next_token(state, tTRIVIA); }
+	{ return rbs_next_token(lexer, tTRIVIA); }
 #line 136 "src/lexer.c"
 yy6:
-	rbs_skip(state);
+	rbs_skip(lexer);
 	goto yy5;
 yy7:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '=') goto yy24;
 	if (yych == '~') goto yy24;
 yy8:
 #line 48 "src/lexer.re"
-	{ return rbs_next_token(state, tOPERATOR); }
+	{ return rbs_next_token(lexer, tOPERATOR); }
 #line 148 "src/lexer.c"
 yy9:
 	yyaccept = 0;
-	rbs_skip(state);
-	backup = *state;
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	backup = *lexer;
+	yych = rbs_peek(lexer);
 	if (yych <= 0x00000000) goto yy3;
 	goto yy67;
 yy10:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= 0x00000000) goto yy11;
 	if (yych != '\n') goto yy10;
 yy11:
 #line 59 "src/lexer.re"
 	{
         return rbs_next_token(
-          state,
-          state->first_token_of_line ? tLINECOMMENT : tCOMMENT
+          lexer,
+          lexer->first_token_of_line ? tLINECOMMENT : tCOMMENT
         );
       }
 #line 169 "src/lexer.c"
 yy12:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= ')') {
 		if (yych <= 0x0000001F) {
 			if (yych <= '\n') {
@@ -214,55 +214,55 @@ yy12:
 	}
 yy13:
 	yyaccept = 1;
-	rbs_skip(state);
-	backup = *state;
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	backup = *lexer;
+	yych = rbs_peek(lexer);
 	if (yych == 'a') goto yy74;
 	goto yy8;
 yy14:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 33 "src/lexer.re"
-	{ return rbs_next_token(state, pAMP); }
+	{ return rbs_next_token(lexer, pAMP); }
 #line 227 "src/lexer.c"
 yy15:
 	yyaccept = 0;
-	rbs_skip(state);
-	backup = *state;
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	backup = *lexer;
+	yych = rbs_peek(lexer);
 	if (yych <= 0x00000000) goto yy3;
 	goto yy76;
 yy16:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 24 "src/lexer.re"
-	{ return rbs_next_token(state, pLPAREN); }
+	{ return rbs_next_token(lexer, pLPAREN); }
 #line 239 "src/lexer.c"
 yy17:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 25 "src/lexer.re"
-	{ return rbs_next_token(state, pRPAREN); }
+	{ return rbs_next_token(lexer, pRPAREN); }
 #line 244 "src/lexer.c"
 yy18:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '*') goto yy80;
 #line 35 "src/lexer.re"
-	{ return rbs_next_token(state, pSTAR); }
+	{ return rbs_next_token(lexer, pSTAR); }
 #line 251 "src/lexer.c"
 yy19:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '/') goto yy8;
 	if (yych <= '9') goto yy25;
 	if (yych == '@') goto yy24;
 	goto yy8;
 yy20:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 30 "src/lexer.re"
-	{ return rbs_next_token(state, pCOMMA); }
+	{ return rbs_next_token(lexer, pCOMMA); }
 #line 263 "src/lexer.c"
 yy21:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') goto yy8;
 		if (yych <= '9') goto yy25;
@@ -274,32 +274,32 @@ yy21:
 	}
 yy22:
 	yyaccept = 2;
-	rbs_skip(state);
-	backup = *state;
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	backup = *lexer;
+	yych = rbs_peek(lexer);
 	if (yych == '.') goto yy82;
 yy23:
 #line 37 "src/lexer.re"
-	{ return rbs_next_token(state, pDOT); }
+	{ return rbs_next_token(lexer, pDOT); }
 #line 285 "src/lexer.c"
 yy24:
-	rbs_skip(state);
+	rbs_skip(lexer);
 	goto yy8;
 yy25:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '/') goto yy26;
 	if (yych <= '9') goto yy25;
 	if (yych == '_') goto yy25;
 yy26:
 #line 51 "src/lexer.re"
-	{ return rbs_next_token(state, tINTEGER); }
+	{ return rbs_next_token(lexer, tINTEGER); }
 #line 298 "src/lexer.c"
 yy27:
 	yyaccept = 3;
-	rbs_skip(state);
-	backup = *state;
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	backup = *lexer;
+	yych = rbs_peek(lexer);
 	switch (yych) {
 		case '!': goto yy83;
 		case '"': goto yy85;
@@ -378,21 +378,21 @@ yy27:
 	}
 yy28:
 #line 44 "src/lexer.re"
-	{ return rbs_next_token(state, pCOLON); }
+	{ return rbs_next_token(lexer, pCOLON); }
 #line 383 "src/lexer.c"
 yy29:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= ';') goto yy30;
 	if (yych <= '<') goto yy24;
 	if (yych <= '=') goto yy99;
 yy30:
 #line 46 "src/lexer.re"
-	{ return rbs_next_token(state, pLT); }
+	{ return rbs_next_token(lexer, pLT); }
 #line 393 "src/lexer.c"
 yy31:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '>') {
 		if (yych <= '<') goto yy32;
 		if (yych <= '=') goto yy100;
@@ -402,24 +402,24 @@ yy31:
 	}
 yy32:
 #line 43 "src/lexer.re"
-	{ return rbs_next_token(state, pEQ); }
+	{ return rbs_next_token(lexer, pEQ); }
 #line 407 "src/lexer.c"
 yy33:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '<') goto yy8;
 	if (yych <= '>') goto yy24;
 	goto yy8;
 yy34:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 34 "src/lexer.re"
-	{ return rbs_next_token(state, pQUESTION); }
+	{ return rbs_next_token(lexer, pQUESTION); }
 #line 418 "src/lexer.c"
 yy35:
 	yyaccept = 0;
-	rbs_skip(state);
-	backup = *state;
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	backup = *lexer;
+	yych = rbs_peek(lexer);
 	if (yych <= '^') {
 		if (yych <= '?') goto yy3;
 		if (yych <= '@') goto yy102;
@@ -431,8 +431,8 @@ yy35:
 		goto yy3;
 	}
 yy36:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -451,28 +451,28 @@ yy36:
 	}
 yy37:
 #line 129 "src/lexer.re"
-	{ return rbs_next_token(state, tUIDENT); }
+	{ return rbs_next_token(lexer, tUIDENT); }
 #line 456 "src/lexer.c"
 yy38:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == ']') goto yy107;
 #line 26 "src/lexer.re"
-	{ return rbs_next_token(state, pLBRACKET); }
+	{ return rbs_next_token(lexer, pLBRACKET); }
 #line 463 "src/lexer.c"
 yy39:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 27 "src/lexer.re"
-	{ return rbs_next_token(state, pRBRACKET); }
+	{ return rbs_next_token(lexer, pRBRACKET); }
 #line 468 "src/lexer.c"
 yy40:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 32 "src/lexer.re"
-	{ return rbs_next_token(state, pHAT); }
+	{ return rbs_next_token(lexer, pHAT); }
 #line 473 "src/lexer.c"
 yy41:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -492,13 +492,13 @@ yy41:
 	}
 yy42:
 #line 132 "src/lexer.re"
-	{ return rbs_next_token(state, tULLIDENT); }
+	{ return rbs_next_token(lexer, tULLIDENT); }
 #line 497 "src/lexer.c"
 yy43:
 	yyaccept = 4;
-	rbs_skip(state);
-	backup = *state;
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	backup = *lexer;
+	yych = rbs_peek(lexer);
 	if (yych <= ' ') {
 		if (yych <= 0x00000000) goto yy44;
 		if (yych <= 0x0000001F) goto yy114;
@@ -507,11 +507,11 @@ yy43:
 	}
 yy44:
 #line 39 "src/lexer.re"
-	{  return rbs_next_token(state, tOPERATOR); }
+	{  return rbs_next_token(lexer, tOPERATOR); }
 #line 512 "src/lexer.c"
 yy45:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= 'r') {
 		if (yych == 'l') goto yy115;
 		goto yy53;
@@ -522,37 +522,37 @@ yy45:
 	}
 yy46:
 #line 128 "src/lexer.re"
-	{ return rbs_next_token(state, tLIDENT); }
+	{ return rbs_next_token(lexer, tLIDENT); }
 #line 527 "src/lexer.c"
 yy47:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'o') goto yy119;
 	goto yy53;
 yy48:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'l') goto yy120;
 	goto yy53;
 yy49:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy121;
 	goto yy53;
 yy50:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'n') goto yy122;
 	if (yych == 'x') goto yy123;
 	goto yy53;
 yy51:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'a') goto yy124;
 	goto yy53;
 yy52:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 yy53:
 	if (yych <= '=') {
 		if (yych <= '/') {
@@ -575,40 +575,40 @@ yy53:
 		}
 	}
 yy54:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'n') goto yy125;
 	goto yy53;
 yy55:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'o') goto yy127;
 	goto yy53;
 yy56:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'i') goto yy128;
 	goto yy53;
 yy57:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'u') goto yy129;
 	goto yy53;
 yy58:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'r') goto yy130;
 	if (yych == 'u') goto yy131;
 	goto yy53;
 yy59:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy132;
 	if (yych == 'i') goto yy133;
 	goto yy53;
 yy60:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= 'q') {
 		if (yych == 'o') goto yy134;
 		goto yy53;
@@ -618,34 +618,34 @@ yy60:
 		goto yy53;
 	}
 yy61:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'n') goto yy137;
 	if (yych == 's') goto yy138;
 	goto yy53;
 yy62:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'o') goto yy139;
 	goto yy53;
 yy63:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 28 "src/lexer.re"
-	{ return rbs_next_token(state, pLBRACE); }
+	{ return rbs_next_token(lexer, pLBRACE); }
 #line 636 "src/lexer.c"
 yy64:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 31 "src/lexer.re"
-	{ return rbs_next_token(state, pBAR); }
+	{ return rbs_next_token(lexer, pBAR); }
 #line 641 "src/lexer.c"
 yy65:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 29 "src/lexer.re"
-	{ return rbs_next_token(state, pRBRACE); }
+	{ return rbs_next_token(lexer, pRBRACE); }
 #line 646 "src/lexer.c"
 yy66:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 yy67:
 	if (yych <= '"') {
 		if (yych <= 0x00000000) goto yy68;
@@ -656,7 +656,7 @@ yy67:
 		goto yy66;
 	}
 yy68:
-	*state = backup;
+	*lexer = backup;
 	if (yyaccept <= 3) {
 		if (yyaccept <= 1) {
 			if (yyaccept == 0) {
@@ -683,19 +683,19 @@ yy68:
 		}
 	}
 yy69:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 106 "src/lexer.re"
-	{ return rbs_next_token(state, tDQSTRING); }
+	{ return rbs_next_token(lexer, tDQSTRING); }
 #line 690 "src/lexer.c"
 yy70:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'u') goto yy140;
 	if (yych == 'x') goto yy141;
 	goto yy66;
 yy71:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= ',') {
 		if (yych <= '\f') {
 			if (yych <= 0x00000000) goto yy72;
@@ -724,14 +724,14 @@ yy71:
 	}
 yy72:
 #line 139 "src/lexer.re"
-	{ return rbs_next_token(state, tGIDENT); }
+	{ return rbs_next_token(lexer, tGIDENT); }
 #line 729 "src/lexer.c"
 yy73:
-	rbs_skip(state);
+	rbs_skip(lexer);
 	goto yy72;
 yy74:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= 'Z') {
 		if (yych <= '(') {
 			if (yych <= '\'') goto yy68;
@@ -751,8 +751,8 @@ yy74:
 		}
 	}
 yy75:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 yy76:
 	if (yych <= '\'') {
 		if (yych <= 0x00000000) goto yy68;
@@ -762,14 +762,14 @@ yy76:
 		goto yy75;
 	}
 yy77:
-	rbs_skip(state);
+	rbs_skip(lexer);
 yy78:
 #line 107 "src/lexer.re"
-	{ return rbs_next_token(state, tSQSTRING); }
+	{ return rbs_next_token(lexer, tSQSTRING); }
 #line 770 "src/lexer.c"
 yy79:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '\'') {
 		if (yych <= 0x00000000) goto yy68;
 		if (yych <= '&') goto yy75;
@@ -779,32 +779,32 @@ yy79:
 		goto yy75;
 	}
 yy80:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 36 "src/lexer.re"
-	{ return rbs_next_token(state, pSTAR2); }
+	{ return rbs_next_token(lexer, pSTAR2); }
 #line 786 "src/lexer.c"
 yy81:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 41 "src/lexer.re"
-	{ return rbs_next_token(state, pARROW); }
+	{ return rbs_next_token(lexer, pARROW); }
 #line 791 "src/lexer.c"
 yy82:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '.') goto yy148;
 	goto yy68;
 yy83:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '=') goto yy87;
 	if (yych == '~') goto yy87;
 yy84:
 #line 126 "src/lexer.re"
-	{ return rbs_next_token(state, tSYMBOL); }
+	{ return rbs_next_token(lexer, tSYMBOL); }
 #line 805 "src/lexer.c"
 yy85:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '"') {
 		if (yych <= 0x00000000) goto yy68;
 		if (yych <= '!') goto yy85;
@@ -814,8 +814,8 @@ yy85:
 		goto yy85;
 	}
 yy86:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= ')') {
 		if (yych <= 0x0000001F) {
 			if (yych <= '\n') {
@@ -860,11 +860,11 @@ yy86:
 		}
 	}
 yy87:
-	rbs_skip(state);
+	rbs_skip(lexer);
 	goto yy84;
 yy88:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '\'') {
 		if (yych <= 0x00000000) goto yy68;
 		if (yych <= '&') goto yy88;
@@ -874,42 +874,42 @@ yy88:
 		goto yy88;
 	}
 yy89:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '*') goto yy87;
 	goto yy84;
 yy90:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '@') goto yy87;
 	goto yy84;
 yy91:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 45 "src/lexer.re"
-	{ return rbs_next_token(state, pCOLON2); }
+	{ return rbs_next_token(lexer, pCOLON2); }
 #line 891 "src/lexer.c"
 yy92:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= ';') goto yy84;
 	if (yych <= '<') goto yy87;
 	if (yych <= '=') goto yy157;
 	goto yy84;
 yy93:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '=') goto yy158;
 	if (yych == '~') goto yy87;
 	goto yy68;
 yy94:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '<') goto yy84;
 	if (yych <= '>') goto yy87;
 	goto yy84;
 yy95:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '^') {
 		if (yych <= '?') goto yy68;
 		if (yych <= '@') goto yy159;
@@ -921,8 +921,8 @@ yy95:
 		goto yy68;
 	}
 yy96:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '>') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy162;
@@ -942,31 +942,31 @@ yy96:
 	}
 yy97:
 #line 122 "src/lexer.re"
-	{ return rbs_next_token(state, tSYMBOL); }
+	{ return rbs_next_token(lexer, tSYMBOL); }
 #line 947 "src/lexer.c"
 yy98:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == ']') goto yy158;
 	goto yy68;
 yy99:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '>') goto yy24;
 	goto yy8;
 yy100:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '=') goto yy24;
 	goto yy8;
 yy101:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 42 "src/lexer.re"
-	{ return rbs_next_token(state, pFATARROW); }
+	{ return rbs_next_token(lexer, pFATARROW); }
 #line 967 "src/lexer.c"
 yy102:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '^') {
 		if (yych <= '@') goto yy68;
 		if (yych <= 'Z') goto yy163;
@@ -977,8 +977,8 @@ yy102:
 		goto yy68;
 	}
 yy103:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= 'Z') {
 		if (yych <= '/') goto yy104;
 		if (yych <= '9') goto yy103;
@@ -993,28 +993,28 @@ yy103:
 	}
 yy104:
 #line 136 "src/lexer.re"
-	{ return rbs_next_token(state, tAIDENT); }
+	{ return rbs_next_token(lexer, tAIDENT); }
 #line 998 "src/lexer.c"
 yy105:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 133 "src/lexer.re"
-	{ return rbs_next_token(state, tBANGIDENT); }
+	{ return rbs_next_token(lexer, tBANGIDENT); }
 #line 1003 "src/lexer.c"
 yy106:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 134 "src/lexer.re"
-	{ return rbs_next_token(state, tEQIDENT); }
+	{ return rbs_next_token(lexer, tEQIDENT); }
 #line 1008 "src/lexer.c"
 yy107:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '=') goto yy24;
 #line 47 "src/lexer.re"
-	{ return rbs_next_token(state, pAREF_OPR); }
+	{ return rbs_next_token(lexer, pAREF_OPR); }
 #line 1015 "src/lexer.c"
 yy108:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 yy109:
 	if (yych <= '=') {
 		if (yych <= '/') {
@@ -1034,11 +1034,11 @@ yy109:
 	}
 yy110:
 #line 130 "src/lexer.re"
-	{ return rbs_next_token(state, tULLIDENT); }
+	{ return rbs_next_token(lexer, tULLIDENT); }
 #line 1039 "src/lexer.c"
 yy111:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -1057,27 +1057,27 @@ yy111:
 	}
 yy112:
 #line 131 "src/lexer.re"
-	{ return rbs_next_token(state, tULIDENT); }
+	{ return rbs_next_token(lexer, tULIDENT); }
 #line 1062 "src/lexer.c"
 yy113:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 't') goto yy165;
 	goto yy109;
 yy114:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= 0x00000000) goto yy68;
 	if (yych == '`') goto yy166;
 	goto yy114;
 yy115:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'i') goto yy167;
 	goto yy53;
 yy116:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -1096,47 +1096,47 @@ yy116:
 	}
 yy117:
 #line 96 "src/lexer.re"
-	{ return rbs_next_token(state, kAS); }
+	{ return rbs_next_token(lexer, kAS); }
 #line 1101 "src/lexer.c"
 yy118:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 't') goto yy168;
 	goto yy53;
 yy119:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'o') goto yy169;
 	if (yych == 't') goto yy170;
 	goto yy53;
 yy120:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'a') goto yy172;
 	goto yy53;
 yy121:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'f') goto yy173;
 	goto yy53;
 yy122:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'd') goto yy175;
 	goto yy53;
 yy123:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 't') goto yy177;
 	goto yy53;
 yy124:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'l') goto yy178;
 	goto yy53;
 yy125:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '^') {
 		if (yych <= '9') {
 			if (yych == '!') goto yy105;
@@ -1166,78 +1166,78 @@ yy125:
 	}
 yy126:
 #line 77 "src/lexer.re"
-	{ return rbs_next_token(state, kIN); }
+	{ return rbs_next_token(lexer, kIN); }
 #line 1171 "src/lexer.c"
 yy127:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'd') goto yy182;
 	goto yy53;
 yy128:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'l') goto yy183;
 	goto yy53;
 yy129:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 't') goto yy185;
 	goto yy53;
 yy130:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy187;
 	if (yych == 'i') goto yy188;
 	goto yy53;
 yy131:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'b') goto yy189;
 	goto yy53;
 yy132:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'l') goto yy190;
 	goto yy53;
 yy133:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'n') goto yy191;
 	goto yy53;
 yy134:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'p') goto yy192;
 	goto yy53;
 yy135:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'u') goto yy194;
 	goto yy53;
 yy136:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'p') goto yy195;
 	goto yy53;
 yy137:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'c') goto yy196;
 	if (yych == 't') goto yy197;
 	goto yy53;
 yy138:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy198;
 	goto yy53;
 yy139:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'i') goto yy200;
 	goto yy53;
 yy140:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '@') {
 		if (yych <= '/') goto yy68;
 		if (yych <= '9') goto yy201;
@@ -1249,48 +1249,48 @@ yy140:
 		goto yy68;
 	}
 yy141:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '/') goto yy68;
 	if (yych <= '9') goto yy66;
 	if (yych <= '`') goto yy68;
 	if (yych <= 'f') goto yy66;
 	goto yy68;
 yy142:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= 0x00000000) goto yy68;
 	if (yych == ')') goto yy202;
 	goto yy142;
 yy143:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= 0x00000000) goto yy68;
 	if (yych == '>') goto yy203;
 	goto yy143;
 yy144:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= 0x00000000) goto yy68;
 	if (yych == ']') goto yy204;
 	goto yy144;
 yy145:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= 0x00000000) goto yy68;
 	if (yych == '}') goto yy205;
 	goto yy145;
 yy146:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= 0x00000000) goto yy68;
 	if (yych == '|') goto yy206;
 	goto yy146;
 yy147:
 	yyaccept = 5;
-	rbs_skip(state);
-	backup = *state;
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	backup = *lexer;
+	yych = rbs_peek(lexer);
 	if (yych <= '\'') {
 		if (yych <= 0x00000000) goto yy78;
 		if (yych <= '&') goto yy75;
@@ -1300,24 +1300,24 @@ yy147:
 		goto yy75;
 	}
 yy148:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 38 "src/lexer.re"
-	{ return rbs_next_token(state, pDOT3); }
+	{ return rbs_next_token(lexer, pDOT3); }
 #line 1307 "src/lexer.c"
 yy149:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 108 "src/lexer.re"
-	{ return rbs_next_token(state, tDQSYMBOL); }
+	{ return rbs_next_token(lexer, tDQSYMBOL); }
 #line 1312 "src/lexer.c"
 yy150:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'u') goto yy207;
 	if (yych == 'x') goto yy208;
 	goto yy85;
 yy151:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= ',') {
 		if (yych <= '\f') {
 			if (yych <= 0x00000000) goto yy152;
@@ -1346,20 +1346,20 @@ yy151:
 	}
 yy152:
 #line 125 "src/lexer.re"
-	{ return rbs_next_token(state, tSYMBOL); }
+	{ return rbs_next_token(lexer, tSYMBOL); }
 #line 1351 "src/lexer.c"
 yy153:
-	rbs_skip(state);
+	rbs_skip(lexer);
 	goto yy152;
 yy154:
-	rbs_skip(state);
+	rbs_skip(lexer);
 yy155:
 #line 109 "src/lexer.re"
-	{ return rbs_next_token(state, tSQSYMBOL); }
+	{ return rbs_next_token(lexer, tSQSYMBOL); }
 #line 1360 "src/lexer.c"
 yy156:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '\'') {
 		if (yych <= 0x00000000) goto yy68;
 		if (yych <= '&') goto yy88;
@@ -1369,18 +1369,18 @@ yy156:
 		goto yy88;
 	}
 yy157:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '>') goto yy87;
 	goto yy84;
 yy158:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '=') goto yy87;
 	goto yy84;
 yy159:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '^') {
 		if (yych <= '@') goto yy68;
 		if (yych <= 'Z') goto yy210;
@@ -1391,8 +1391,8 @@ yy159:
 		goto yy68;
 	}
 yy160:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '>') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy212;
@@ -1412,14 +1412,14 @@ yy160:
 	}
 yy161:
 #line 123 "src/lexer.re"
-	{ return rbs_next_token(state, tSYMBOL); }
+	{ return rbs_next_token(lexer, tSYMBOL); }
 #line 1417 "src/lexer.c"
 yy162:
-	rbs_skip(state);
+	rbs_skip(lexer);
 	goto yy97;
 yy163:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= 'Z') {
 		if (yych <= '/') goto yy164;
 		if (yych <= '9') goto yy163;
@@ -1434,36 +1434,36 @@ yy163:
 	}
 yy164:
 #line 137 "src/lexer.re"
-	{ return rbs_next_token(state, tA2IDENT); }
+	{ return rbs_next_token(lexer, tA2IDENT); }
 #line 1439 "src/lexer.c"
 yy165:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'o') goto yy213;
 	goto yy109;
 yy166:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 40 "src/lexer.re"
-	{ return rbs_next_token(state, tQIDENT); }
+	{ return rbs_next_token(lexer, tQIDENT); }
 #line 1449 "src/lexer.c"
 yy167:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'a') goto yy214;
 	goto yy53;
 yy168:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'r') goto yy215;
 	goto yy53;
 yy169:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'l') goto yy216;
 	goto yy53;
 yy170:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -1482,16 +1482,16 @@ yy170:
 	}
 yy171:
 #line 71 "src/lexer.re"
-	{ return rbs_next_token(state, kBOT); }
+	{ return rbs_next_token(lexer, kBOT); }
 #line 1487 "src/lexer.c"
 yy172:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 's') goto yy218;
 	goto yy53;
 yy173:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -1510,11 +1510,11 @@ yy173:
 	}
 yy174:
 #line 73 "src/lexer.re"
-	{ return rbs_next_token(state, kDEF); }
+	{ return rbs_next_token(lexer, kDEF); }
 #line 1515 "src/lexer.c"
 yy175:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -1533,41 +1533,41 @@ yy175:
 	}
 yy176:
 #line 74 "src/lexer.re"
-	{ return rbs_next_token(state, kEND); }
+	{ return rbs_next_token(lexer, kEND); }
 #line 1538 "src/lexer.c"
 yy177:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy219;
 	goto yy53;
 yy178:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 's') goto yy220;
 	goto yy53;
 yy179:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'l') goto yy221;
 	goto yy53;
 yy180:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 't') goto yy222;
 	goto yy53;
 yy181:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy223;
 	goto yy53;
 yy182:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'u') goto yy224;
 	goto yy53;
 yy183:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -1586,11 +1586,11 @@ yy183:
 	}
 yy184:
 #line 82 "src/lexer.re"
-	{ return rbs_next_token(state, kNIL); }
+	{ return rbs_next_token(lexer, kNIL); }
 #line 1591 "src/lexer.c"
 yy185:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -1609,36 +1609,36 @@ yy185:
 	}
 yy186:
 #line 83 "src/lexer.re"
-	{ return rbs_next_token(state, kOUT); }
+	{ return rbs_next_token(lexer, kOUT); }
 #line 1614 "src/lexer.c"
 yy187:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'p') goto yy225;
 	goto yy53;
 yy188:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'v') goto yy226;
 	goto yy53;
 yy189:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'l') goto yy227;
 	goto yy53;
 yy190:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'f') goto yy228;
 	goto yy53;
 yy191:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'g') goto yy230;
 	goto yy53;
 yy192:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -1657,31 +1657,31 @@ yy192:
 	}
 yy193:
 #line 89 "src/lexer.re"
-	{ return rbs_next_token(state, kTOP); }
+	{ return rbs_next_token(lexer, kTOP); }
 #line 1662 "src/lexer.c"
 yy194:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy231;
 	goto yy53;
 yy195:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy233;
 	goto yy53;
 yy196:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'h') goto yy235;
 	goto yy53;
 yy197:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'y') goto yy236;
 	goto yy53;
 yy198:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -1700,16 +1700,16 @@ yy198:
 	}
 yy199:
 #line 95 "src/lexer.re"
-	{ return rbs_next_token(state, kUSE); }
+	{ return rbs_next_token(lexer, kUSE); }
 #line 1705 "src/lexer.c"
 yy200:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'd') goto yy237;
 	goto yy53;
 yy201:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '@') {
 		if (yych <= '/') goto yy68;
 		if (yych <= '9') goto yy239;
@@ -1721,33 +1721,33 @@ yy201:
 		goto yy68;
 	}
 yy202:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 54 "src/lexer.re"
-	{ return rbs_next_token(state, tANNOTATION); }
+	{ return rbs_next_token(lexer, tANNOTATION); }
 #line 1728 "src/lexer.c"
 yy203:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 57 "src/lexer.re"
-	{ return rbs_next_token(state, tANNOTATION); }
+	{ return rbs_next_token(lexer, tANNOTATION); }
 #line 1733 "src/lexer.c"
 yy204:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 55 "src/lexer.re"
-	{ return rbs_next_token(state, tANNOTATION); }
+	{ return rbs_next_token(lexer, tANNOTATION); }
 #line 1738 "src/lexer.c"
 yy205:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 53 "src/lexer.re"
-	{ return rbs_next_token(state, tANNOTATION); }
+	{ return rbs_next_token(lexer, tANNOTATION); }
 #line 1743 "src/lexer.c"
 yy206:
-	rbs_skip(state);
+	rbs_skip(lexer);
 #line 56 "src/lexer.re"
-	{ return rbs_next_token(state, tANNOTATION); }
+	{ return rbs_next_token(lexer, tANNOTATION); }
 #line 1748 "src/lexer.c"
 yy207:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '@') {
 		if (yych <= '/') goto yy68;
 		if (yych <= '9') goto yy240;
@@ -1759,8 +1759,8 @@ yy207:
 		goto yy68;
 	}
 yy208:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '/') goto yy68;
 	if (yych <= '9') goto yy85;
 	if (yych <= '`') goto yy68;
@@ -1768,9 +1768,9 @@ yy208:
 	goto yy68;
 yy209:
 	yyaccept = 6;
-	rbs_skip(state);
-	backup = *state;
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	backup = *lexer;
+	yych = rbs_peek(lexer);
 	if (yych <= '\'') {
 		if (yych <= 0x00000000) goto yy155;
 		if (yych <= '&') goto yy88;
@@ -1780,8 +1780,8 @@ yy209:
 		goto yy88;
 	}
 yy210:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '>') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy241;
@@ -1801,29 +1801,29 @@ yy210:
 	}
 yy211:
 #line 124 "src/lexer.re"
-	{ return rbs_next_token(state, tSYMBOL); }
+	{ return rbs_next_token(lexer, tSYMBOL); }
 #line 1806 "src/lexer.c"
 yy212:
-	rbs_skip(state);
+	rbs_skip(lexer);
 	goto yy161;
 yy213:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'd') goto yy242;
 	goto yy109;
 yy214:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 's') goto yy243;
 	goto yy53;
 yy215:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '_') goto yy245;
 	goto yy53;
 yy216:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -1842,61 +1842,61 @@ yy216:
 	}
 yy217:
 #line 70 "src/lexer.re"
-	{ return rbs_next_token(state, kBOOL); }
+	{ return rbs_next_token(lexer, kBOOL); }
 #line 1847 "src/lexer.c"
 yy218:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 's') goto yy246;
 	goto yy53;
 yy219:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'n') goto yy248;
 	goto yy53;
 yy220:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy249;
 	goto yy53;
 yy221:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'u') goto yy251;
 	goto yy53;
 yy222:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'a') goto yy252;
 	goto yy53;
 yy223:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'r') goto yy253;
 	goto yy53;
 yy224:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'l') goto yy254;
 	goto yy53;
 yy225:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy255;
 	goto yy53;
 yy226:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'a') goto yy256;
 	goto yy53;
 yy227:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'i') goto yy257;
 	goto yy53;
 yy228:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -1915,16 +1915,16 @@ yy228:
 	}
 yy229:
 #line 87 "src/lexer.re"
-	{ return rbs_next_token(state, kSELF); }
+	{ return rbs_next_token(lexer, kSELF); }
 #line 1920 "src/lexer.c"
 yy230:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'l') goto yy258;
 	goto yy53;
 yy231:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -1943,11 +1943,11 @@ yy231:
 	}
 yy232:
 #line 90 "src/lexer.re"
-	{ return rbs_next_token(state, kTRUE); }
+	{ return rbs_next_token(lexer, kTRUE); }
 #line 1948 "src/lexer.c"
 yy233:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -1966,21 +1966,21 @@ yy233:
 	}
 yy234:
 #line 91 "src/lexer.re"
-	{ return rbs_next_token(state, kTYPE); }
+	{ return rbs_next_token(lexer, kTYPE); }
 #line 1971 "src/lexer.c"
 yy235:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy259;
 	goto yy53;
 yy236:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'p') goto yy260;
 	goto yy53;
 yy237:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -1999,11 +1999,11 @@ yy237:
 	}
 yy238:
 #line 94 "src/lexer.re"
-	{ return rbs_next_token(state, kVOID); }
+	{ return rbs_next_token(lexer, kVOID); }
 #line 2004 "src/lexer.c"
 yy239:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '@') {
 		if (yych <= '/') goto yy68;
 		if (yych <= '9') goto yy261;
@@ -2015,8 +2015,8 @@ yy239:
 		goto yy68;
 	}
 yy240:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '@') {
 		if (yych <= '/') goto yy68;
 		if (yych <= '9') goto yy262;
@@ -2028,16 +2028,16 @@ yy240:
 		goto yy68;
 	}
 yy241:
-	rbs_skip(state);
+	rbs_skip(lexer);
 	goto yy211;
 yy242:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'o') goto yy263;
 	goto yy109;
 yy243:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2056,11 +2056,11 @@ yy243:
 	}
 yy244:
 #line 66 "src/lexer.re"
-	{ return rbs_next_token(state, kALIAS); }
+	{ return rbs_next_token(lexer, kALIAS); }
 #line 2061 "src/lexer.c"
 yy245:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= 'q') {
 		if (yych == 'a') goto yy264;
 		goto yy53;
@@ -2070,8 +2070,8 @@ yy245:
 		goto yy53;
 	}
 yy246:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2090,16 +2090,16 @@ yy246:
 	}
 yy247:
 #line 72 "src/lexer.re"
-	{ return rbs_next_token(state, kCLASS); }
+	{ return rbs_next_token(lexer, kCLASS); }
 #line 2095 "src/lexer.c"
 yy248:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'd') goto yy267;
 	goto yy53;
 yy249:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2118,61 +2118,61 @@ yy249:
 	}
 yy250:
 #line 76 "src/lexer.re"
-	{ return rbs_next_token(state, kFALSE); }
+	{ return rbs_next_token(lexer, kFALSE); }
 #line 2123 "src/lexer.c"
 yy251:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'd') goto yy269;
 	goto yy53;
 yy252:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'n') goto yy270;
 	goto yy53;
 yy253:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'f') goto yy271;
 	goto yy53;
 yy254:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy272;
 	goto yy53;
 yy255:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'n') goto yy274;
 	goto yy53;
 yy256:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 't') goto yy275;
 	goto yy53;
 yy257:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'c') goto yy276;
 	goto yy53;
 yy258:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy278;
 	goto yy53;
 yy259:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'c') goto yy279;
 	goto yy53;
 yy260:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy280;
 	goto yy53;
 yy261:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '@') {
 		if (yych <= '/') goto yy68;
 		if (yych <= '9') goto yy66;
@@ -2184,8 +2184,8 @@ yy261:
 		goto yy68;
 	}
 yy262:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '@') {
 		if (yych <= '/') goto yy68;
 		if (yych <= '9') goto yy281;
@@ -2197,28 +2197,28 @@ yy262:
 		goto yy68;
 	}
 yy263:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '_') goto yy282;
 	goto yy109;
 yy264:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'c') goto yy283;
 	goto yy53;
 yy265:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy284;
 	goto yy53;
 yy266:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'r') goto yy285;
 	goto yy53;
 yy267:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2237,26 +2237,26 @@ yy267:
 	}
 yy268:
 #line 75 "src/lexer.re"
-	{ return rbs_next_token(state, kEXTEND); }
+	{ return rbs_next_token(lexer, kEXTEND); }
 #line 2242 "src/lexer.c"
 yy269:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy286;
 	goto yy53;
 yy270:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'c') goto yy288;
 	goto yy53;
 yy271:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'a') goto yy289;
 	goto yy53;
 yy272:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2275,21 +2275,21 @@ yy272:
 	}
 yy273:
 #line 81 "src/lexer.re"
-	{ return rbs_next_token(state, kMODULE); }
+	{ return rbs_next_token(lexer, kMODULE); }
 #line 2280 "src/lexer.c"
 yy274:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'd') goto yy290;
 	goto yy53;
 yy275:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy292;
 	goto yy53;
 yy276:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2308,26 +2308,26 @@ yy276:
 	}
 yy277:
 #line 86 "src/lexer.re"
-	{ return rbs_next_token(state, kPUBLIC); }
+	{ return rbs_next_token(lexer, kPUBLIC); }
 #line 2313 "src/lexer.c"
 yy278:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 't') goto yy294;
 	goto yy53;
 yy279:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'k') goto yy295;
 	goto yy53;
 yy280:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'd') goto yy296;
 	goto yy53;
 yy281:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '@') {
 		if (yych <= '/') goto yy68;
 		if (yych <= '9') goto yy85;
@@ -2339,28 +2339,28 @@ yy281:
 		goto yy68;
 	}
 yy282:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == '_') goto yy298;
 	goto yy109;
 yy283:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'c') goto yy300;
 	goto yy53;
 yy284:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'a') goto yy301;
 	goto yy53;
 yy285:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'i') goto yy302;
 	goto yy53;
 yy286:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2379,21 +2379,21 @@ yy286:
 	}
 yy287:
 #line 78 "src/lexer.re"
-	{ return rbs_next_token(state, kINCLUDE); }
+	{ return rbs_next_token(lexer, kINCLUDE); }
 #line 2384 "src/lexer.c"
 yy288:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy303;
 	goto yy53;
 yy289:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'c') goto yy305;
 	goto yy53;
 yy290:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2412,11 +2412,11 @@ yy290:
 	}
 yy291:
 #line 84 "src/lexer.re"
-	{ return rbs_next_token(state, kPREPEND); }
+	{ return rbs_next_token(lexer, kPREPEND); }
 #line 2417 "src/lexer.c"
 yy292:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2435,21 +2435,21 @@ yy292:
 	}
 yy293:
 #line 85 "src/lexer.re"
-	{ return rbs_next_token(state, kPRIVATE); }
+	{ return rbs_next_token(lexer, kPRIVATE); }
 #line 2440 "src/lexer.c"
 yy294:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'o') goto yy306;
 	goto yy53;
 yy295:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy307;
 	goto yy53;
 yy296:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2468,11 +2468,11 @@ yy296:
 	}
 yy297:
 #line 93 "src/lexer.re"
-	{ return rbs_next_token(state, kUNTYPED); }
+	{ return rbs_next_token(lexer, kUNTYPED); }
 #line 2473 "src/lexer.c"
 yy298:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2491,26 +2491,26 @@ yy298:
 	}
 yy299:
 #line 97 "src/lexer.re"
-	{ return rbs_next_token(state, k__TODO__); }
+	{ return rbs_next_token(lexer, k__TODO__); }
 #line 2496 "src/lexer.c"
 yy300:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy308;
 	goto yy53;
 yy301:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'd') goto yy309;
 	goto yy53;
 yy302:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 't') goto yy310;
 	goto yy53;
 yy303:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2529,41 +2529,41 @@ yy303:
 	}
 yy304:
 #line 79 "src/lexer.re"
-	{ return rbs_next_token(state, kINSTANCE); }
+	{ return rbs_next_token(lexer, kINSTANCE); }
 #line 2534 "src/lexer.c"
 yy305:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy311;
 	goto yy53;
 yy306:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'n') goto yy313;
 	goto yy53;
 yy307:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'd') goto yy315;
 	goto yy53;
 yy308:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 's') goto yy317;
 	goto yy53;
 yy309:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy318;
 	goto yy53;
 yy310:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'e') goto yy319;
 	goto yy53;
 yy311:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2582,11 +2582,11 @@ yy311:
 	}
 yy312:
 #line 80 "src/lexer.re"
-	{ return rbs_next_token(state, kINTERFACE); }
+	{ return rbs_next_token(lexer, kINTERFACE); }
 #line 2587 "src/lexer.c"
 yy313:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2605,11 +2605,11 @@ yy313:
 	}
 yy314:
 #line 88 "src/lexer.re"
-	{ return rbs_next_token(state, kSINGLETON); }
+	{ return rbs_next_token(lexer, kSINGLETON); }
 #line 2610 "src/lexer.c"
 yy315:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2628,31 +2628,31 @@ yy315:
 	}
 yy316:
 #line 92 "src/lexer.re"
-	{ return rbs_next_token(state, kUNCHECKED); }
+	{ return rbs_next_token(lexer, kUNCHECKED); }
 #line 2633 "src/lexer.c"
 yy317:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 's') goto yy320;
 	goto yy53;
 yy318:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'r') goto yy321;
 	goto yy53;
 yy319:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'r') goto yy323;
 	goto yy53;
 yy320:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych == 'o') goto yy325;
 	goto yy53;
 yy321:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2671,11 +2671,11 @@ yy321:
 	}
 yy322:
 #line 68 "src/lexer.re"
-	{ return rbs_next_token(state, kATTRREADER); }
+	{ return rbs_next_token(lexer, kATTRREADER); }
 #line 2676 "src/lexer.c"
 yy323:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2694,14 +2694,14 @@ yy323:
 	}
 yy324:
 #line 69 "src/lexer.re"
-	{ return rbs_next_token(state, kATTRWRITER); }
+	{ return rbs_next_token(lexer, kATTRWRITER); }
 #line 2699 "src/lexer.c"
 yy325:
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych != 'r') goto yy53;
-	rbs_skip(state);
-	yych = rbs_peek(state);
+	rbs_skip(lexer);
+	yych = rbs_peek(lexer);
 	if (yych <= '=') {
 		if (yych <= '/') {
 			if (yych == '!') goto yy105;
@@ -2720,7 +2720,7 @@ yy325:
 	}
 yy326:
 #line 67 "src/lexer.re"
-	{ return rbs_next_token(state, kATTRACCESSOR); }
+	{ return rbs_next_token(lexer, kATTRACCESSOR); }
 #line 2725 "src/lexer.c"
 }
 #line 146 "src/lexer.re"

--- a/src/lexer.re
+++ b/src/lexer.re
@@ -1,19 +1,19 @@
 #include "rbs/lexer.h"
 
-rbs_token_t rbsparser_next_token(rbs_lexer_t *state) {
+rbs_token_t rbsparser_next_token(rbs_lexer_t *lexer) {
   rbs_lexer_t backup;
 
-  backup = *state;
+  backup = *lexer;
 
   /*!re2c
       re2c:flags:u = 1;
       re2c:api:style = free-form;
       re2c:flags:input = custom;
       re2c:define:YYCTYPE = "unsigned int";
-      re2c:define:YYPEEK = "rbs_peek(state)";
-      re2c:define:YYSKIP = "rbs_skip(state);";
-      re2c:define:YYBACKUP = "backup = *state;";
-      re2c:define:YYRESTORE = "*state = backup;";
+      re2c:define:YYPEEK = "rbs_peek(lexer)";
+      re2c:define:YYSKIP = "rbs_skip(lexer);";
+      re2c:define:YYBACKUP = "backup = *lexer;";
+      re2c:define:YYRESTORE = "*lexer = backup;";
       re2c:yyfill:enable  = 0;
 
       word = [a-zA-Z0-9_];
@@ -21,80 +21,80 @@ rbs_token_t rbsparser_next_token(rbs_lexer_t *state) {
       operator = "/" | "~" | "[]=" | "!" | "!=" | "!~" | "-" | "-@" | "+" | "+@"
                | "==" | "===" | "=~" | "<<" | "<=" | "<=>" | ">" | ">=" | ">>" | "%";
 
-      "("   { return rbs_next_token(state, pLPAREN); }
-      ")"   { return rbs_next_token(state, pRPAREN); }
-      "["   { return rbs_next_token(state, pLBRACKET); }
-      "]"   { return rbs_next_token(state, pRBRACKET); }
-      "{"   { return rbs_next_token(state, pLBRACE); }
-      "}"   { return rbs_next_token(state, pRBRACE); }
-      ","   { return rbs_next_token(state, pCOMMA); }
-      "|"   { return rbs_next_token(state, pBAR); }
-      "^"   { return rbs_next_token(state, pHAT); }
-      "&"   { return rbs_next_token(state, pAMP); }
-      "?"   { return rbs_next_token(state, pQUESTION); }
-      "*"   { return rbs_next_token(state, pSTAR); }
-      "**"  { return rbs_next_token(state, pSTAR2); }
-      "."   { return rbs_next_token(state, pDOT); }
-      "..." { return rbs_next_token(state, pDOT3); }
-      "`"   {  return rbs_next_token(state, tOPERATOR); }
-      "`"   [^ :\x00] [^`\x00]* "`" { return rbs_next_token(state, tQIDENT); }
-      "->"  { return rbs_next_token(state, pARROW); }
-      "=>"  { return rbs_next_token(state, pFATARROW); }
-      "="   { return rbs_next_token(state, pEQ); }
-      ":"   { return rbs_next_token(state, pCOLON); }
-      "::"  { return rbs_next_token(state, pCOLON2); }
-      "<"   { return rbs_next_token(state, pLT); }
-      "[]"  { return rbs_next_token(state, pAREF_OPR); }
-      operator  { return rbs_next_token(state, tOPERATOR); }
+      "("   { return rbs_next_token(lexer, pLPAREN); }
+      ")"   { return rbs_next_token(lexer, pRPAREN); }
+      "["   { return rbs_next_token(lexer, pLBRACKET); }
+      "]"   { return rbs_next_token(lexer, pRBRACKET); }
+      "{"   { return rbs_next_token(lexer, pLBRACE); }
+      "}"   { return rbs_next_token(lexer, pRBRACE); }
+      ","   { return rbs_next_token(lexer, pCOMMA); }
+      "|"   { return rbs_next_token(lexer, pBAR); }
+      "^"   { return rbs_next_token(lexer, pHAT); }
+      "&"   { return rbs_next_token(lexer, pAMP); }
+      "?"   { return rbs_next_token(lexer, pQUESTION); }
+      "*"   { return rbs_next_token(lexer, pSTAR); }
+      "**"  { return rbs_next_token(lexer, pSTAR2); }
+      "."   { return rbs_next_token(lexer, pDOT); }
+      "..." { return rbs_next_token(lexer, pDOT3); }
+      "`"   {  return rbs_next_token(lexer, tOPERATOR); }
+      "`"   [^ :\x00] [^`\x00]* "`" { return rbs_next_token(lexer, tQIDENT); }
+      "->"  { return rbs_next_token(lexer, pARROW); }
+      "=>"  { return rbs_next_token(lexer, pFATARROW); }
+      "="   { return rbs_next_token(lexer, pEQ); }
+      ":"   { return rbs_next_token(lexer, pCOLON); }
+      "::"  { return rbs_next_token(lexer, pCOLON2); }
+      "<"   { return rbs_next_token(lexer, pLT); }
+      "[]"  { return rbs_next_token(lexer, pAREF_OPR); }
+      operator  { return rbs_next_token(lexer, tOPERATOR); }
 
       number = [0-9] [0-9_]*;
-      ("-"|"+")? number    { return rbs_next_token(state, tINTEGER); }
+      ("-"|"+")? number    { return rbs_next_token(lexer, tINTEGER); }
 
-      "%a{" [^}\x00]* "}"  { return rbs_next_token(state, tANNOTATION); }
-      "%a(" [^)\x00]* ")"  { return rbs_next_token(state, tANNOTATION); }
-      "%a[" [^\]\x00]* "]" { return rbs_next_token(state, tANNOTATION); }
-      "%a|" [^|\x00]* "|"  { return rbs_next_token(state, tANNOTATION); }
-      "%a<" [^>\x00]* ">"  { return rbs_next_token(state, tANNOTATION); }
+      "%a{" [^}\x00]* "}"  { return rbs_next_token(lexer, tANNOTATION); }
+      "%a(" [^)\x00]* ")"  { return rbs_next_token(lexer, tANNOTATION); }
+      "%a[" [^\]\x00]* "]" { return rbs_next_token(lexer, tANNOTATION); }
+      "%a|" [^|\x00]* "|"  { return rbs_next_token(lexer, tANNOTATION); }
+      "%a<" [^>\x00]* ">"  { return rbs_next_token(lexer, tANNOTATION); }
 
       "#" (. \ [\x00])*    {
         return rbs_next_token(
-          state,
-          state->first_token_of_line ? tLINECOMMENT : tCOMMENT
+          lexer,
+          lexer->first_token_of_line ? tLINECOMMENT : tCOMMENT
         );
       }
 
-      "alias"         { return rbs_next_token(state, kALIAS); }
-      "attr_accessor" { return rbs_next_token(state, kATTRACCESSOR); }
-      "attr_reader"   { return rbs_next_token(state, kATTRREADER); }
-      "attr_writer"   { return rbs_next_token(state, kATTRWRITER); }
-      "bool"          { return rbs_next_token(state, kBOOL); }
-      "bot"           { return rbs_next_token(state, kBOT); }
-      "class"         { return rbs_next_token(state, kCLASS); }
-      "def"           { return rbs_next_token(state, kDEF); }
-      "end"           { return rbs_next_token(state, kEND); }
-      "extend"        { return rbs_next_token(state, kEXTEND); }
-      "false"         { return rbs_next_token(state, kFALSE); }
-      "in"            { return rbs_next_token(state, kIN); }
-      "include"       { return rbs_next_token(state, kINCLUDE); }
-      "instance"      { return rbs_next_token(state, kINSTANCE); }
-      "interface"     { return rbs_next_token(state, kINTERFACE); }
-      "module"        { return rbs_next_token(state, kMODULE); }
-      "nil"           { return rbs_next_token(state, kNIL); }
-      "out"           { return rbs_next_token(state, kOUT); }
-      "prepend"       { return rbs_next_token(state, kPREPEND); }
-      "private"       { return rbs_next_token(state, kPRIVATE); }
-      "public"        { return rbs_next_token(state, kPUBLIC); }
-      "self"          { return rbs_next_token(state, kSELF); }
-      "singleton"     { return rbs_next_token(state, kSINGLETON); }
-      "top"           { return rbs_next_token(state, kTOP); }
-      "true"          { return rbs_next_token(state, kTRUE); }
-      "type"          { return rbs_next_token(state, kTYPE); }
-      "unchecked"     { return rbs_next_token(state, kUNCHECKED); }
-      "untyped"       { return rbs_next_token(state, kUNTYPED); }
-      "void"          { return rbs_next_token(state, kVOID); }
-      "use"           { return rbs_next_token(state, kUSE); }
-      "as"            { return rbs_next_token(state, kAS); }
-      "__todo__"      { return rbs_next_token(state, k__TODO__); }
+      "alias"         { return rbs_next_token(lexer, kALIAS); }
+      "attr_accessor" { return rbs_next_token(lexer, kATTRACCESSOR); }
+      "attr_reader"   { return rbs_next_token(lexer, kATTRREADER); }
+      "attr_writer"   { return rbs_next_token(lexer, kATTRWRITER); }
+      "bool"          { return rbs_next_token(lexer, kBOOL); }
+      "bot"           { return rbs_next_token(lexer, kBOT); }
+      "class"         { return rbs_next_token(lexer, kCLASS); }
+      "def"           { return rbs_next_token(lexer, kDEF); }
+      "end"           { return rbs_next_token(lexer, kEND); }
+      "extend"        { return rbs_next_token(lexer, kEXTEND); }
+      "false"         { return rbs_next_token(lexer, kFALSE); }
+      "in"            { return rbs_next_token(lexer, kIN); }
+      "include"       { return rbs_next_token(lexer, kINCLUDE); }
+      "instance"      { return rbs_next_token(lexer, kINSTANCE); }
+      "interface"     { return rbs_next_token(lexer, kINTERFACE); }
+      "module"        { return rbs_next_token(lexer, kMODULE); }
+      "nil"           { return rbs_next_token(lexer, kNIL); }
+      "out"           { return rbs_next_token(lexer, kOUT); }
+      "prepend"       { return rbs_next_token(lexer, kPREPEND); }
+      "private"       { return rbs_next_token(lexer, kPRIVATE); }
+      "public"        { return rbs_next_token(lexer, kPUBLIC); }
+      "self"          { return rbs_next_token(lexer, kSELF); }
+      "singleton"     { return rbs_next_token(lexer, kSINGLETON); }
+      "top"           { return rbs_next_token(lexer, kTOP); }
+      "true"          { return rbs_next_token(lexer, kTRUE); }
+      "type"          { return rbs_next_token(lexer, kTYPE); }
+      "unchecked"     { return rbs_next_token(lexer, kUNCHECKED); }
+      "untyped"       { return rbs_next_token(lexer, kUNTYPED); }
+      "void"          { return rbs_next_token(lexer, kVOID); }
+      "use"           { return rbs_next_token(lexer, kUSE); }
+      "as"            { return rbs_next_token(lexer, kAS); }
+      "__todo__"      { return rbs_next_token(lexer, k__TODO__); }
 
       unicode_char = "\\u" [0-9a-fA-F]{4};
       oct_char = "\\x" [0-9a-f]{1,2};
@@ -103,10 +103,10 @@ rbs_token_t rbsparser_next_token(rbs_lexer_t *state) {
       dqstring = ["] (unicode_char | oct_char | hex_char | "\\" [^xu] | [^\\"\x00])* ["];
       sqstring = ['] ("\\"['\\] | [^'\x00])* ['];
 
-      dqstring     { return rbs_next_token(state, tDQSTRING); }
-      sqstring     { return rbs_next_token(state, tSQSTRING); }
-      ":" dqstring { return rbs_next_token(state, tDQSYMBOL); }
-      ":" sqstring { return rbs_next_token(state, tSQSYMBOL); }
+      dqstring     { return rbs_next_token(lexer, tDQSTRING); }
+      sqstring     { return rbs_next_token(lexer, tSQSTRING); }
+      ":" dqstring { return rbs_next_token(lexer, tDQSYMBOL); }
+      ":" sqstring { return rbs_next_token(lexer, tSQSYMBOL); }
 
       identifier = [a-zA-Z_] word* [!?=]?;
       symbol_opr = ":|" | ":&" | ":/" | ":%" | ":~" | ":`" | ":^"
@@ -119,29 +119,29 @@ rbs_token_t rbsparser_next_token(rbs_lexer_t *state) {
                    | [~*$?!@\\/;,.=:<>"&'`+]
                    | [^ \t\r\n:;=.,!"$%&()-+~|\\'[\]{}*/<>^\x00]+;
 
-      ":" identifier     { return rbs_next_token(state, tSYMBOL); }
-      ":@" identifier    { return rbs_next_token(state, tSYMBOL); }
-      ":@@" identifier   { return rbs_next_token(state, tSYMBOL); }
-      ":$" global_ident  { return rbs_next_token(state, tSYMBOL); }
-      symbol_opr         { return rbs_next_token(state, tSYMBOL); }
+      ":" identifier     { return rbs_next_token(lexer, tSYMBOL); }
+      ":@" identifier    { return rbs_next_token(lexer, tSYMBOL); }
+      ":@@" identifier   { return rbs_next_token(lexer, tSYMBOL); }
+      ":$" global_ident  { return rbs_next_token(lexer, tSYMBOL); }
+      symbol_opr         { return rbs_next_token(lexer, tSYMBOL); }
 
-      [a-z] word*           { return rbs_next_token(state, tLIDENT); }
-      [A-Z] word*           { return rbs_next_token(state, tUIDENT); }
-      "_" [a-z0-9_] word*   { return rbs_next_token(state, tULLIDENT); }
-      "_" [A-Z] word*       { return rbs_next_token(state, tULIDENT); }
-      "_"                   { return rbs_next_token(state, tULLIDENT); }
-      [a-zA-Z_] word* "!"   { return rbs_next_token(state, tBANGIDENT); }
-      [a-zA-Z_] word* "="   { return rbs_next_token(state, tEQIDENT); }
+      [a-z] word*           { return rbs_next_token(lexer, tLIDENT); }
+      [A-Z] word*           { return rbs_next_token(lexer, tUIDENT); }
+      "_" [a-z0-9_] word*   { return rbs_next_token(lexer, tULLIDENT); }
+      "_" [A-Z] word*       { return rbs_next_token(lexer, tULIDENT); }
+      "_"                   { return rbs_next_token(lexer, tULLIDENT); }
+      [a-zA-Z_] word* "!"   { return rbs_next_token(lexer, tBANGIDENT); }
+      [a-zA-Z_] word* "="   { return rbs_next_token(lexer, tEQIDENT); }
 
-      "@" [a-zA-Z_] word*   { return rbs_next_token(state, tAIDENT); }
-      "@@" [a-zA-Z_] word*  { return rbs_next_token(state, tA2IDENT); }
+      "@" [a-zA-Z_] word*   { return rbs_next_token(lexer, tAIDENT); }
+      "@@" [a-zA-Z_] word*  { return rbs_next_token(lexer, tA2IDENT); }
 
-      "$" global_ident      { return rbs_next_token(state, tGIDENT); }
+      "$" global_ident      { return rbs_next_token(lexer, tGIDENT); }
 
       skip = ([ \t]+|[\r\n]);
 
-      skip     { return rbs_next_token(state, tTRIVIA); }
-      "\x00"   { return rbs_next_eof_token(state); }
-      *        { return rbs_next_token(state, ErrorToken); }
+      skip     { return rbs_next_token(lexer, tTRIVIA); }
+      "\x00"   { return rbs_next_eof_token(lexer); }
+      *        { return rbs_next_token(lexer, ErrorToken); }
   */
 }

--- a/src/lexer.re
+++ b/src/lexer.re
@@ -1,6 +1,6 @@
 #include "rbs/lexer.h"
 
-rbs_token_t rbsparser_next_token(rbs_lexer_t *lexer) {
+rbs_token_t rbs_lexer_next_token(rbs_lexer_t *lexer) {
   rbs_lexer_t backup;
 
   backup = *lexer;

--- a/src/lexer.re
+++ b/src/lexer.re
@@ -1,7 +1,7 @@
 #include "rbs/lexer.h"
 
-rbs_token_t rbsparser_next_token(lexstate *state) {
-  lexstate backup;
+rbs_token_t rbsparser_next_token(rbs_lexer_t *state) {
+  rbs_lexer_t backup;
 
   backup = *state;
 

--- a/src/lexstate.c
+++ b/src/lexstate.c
@@ -104,84 +104,84 @@ int rbs_token_bytes(rbs_token_t tok) {
   return RBS_RANGE_BYTES(tok.range);
 }
 
-unsigned int rbs_peek(rbs_lexer_t *state) {
-  if (state->current.char_pos == state->end_pos) {
-    state->last_char = '\0';
+unsigned int rbs_peek(rbs_lexer_t *lexer) {
+  if (lexer->current.char_pos == lexer->end_pos) {
+    lexer->last_char = '\0';
     return 0;
   } else {
     rbs_string_t str = rbs_string_new(
-      state->string.start + state->current.byte_pos,
-      state->string.end
+      lexer->string.start + lexer->current.byte_pos,
+      lexer->string.end
     );
     unsigned int c = rbs_utf8_string_to_codepoint(str);
-    state->last_char = c;
+    lexer->last_char = c;
     return c;
   }
 }
 
-rbs_token_t rbs_next_token(rbs_lexer_t *state, enum RBSTokenType type) {
+rbs_token_t rbs_next_token(rbs_lexer_t *lexer, enum RBSTokenType type) {
   rbs_token_t t;
 
   t.type = type;
-  t.range.start = state->start;
-  t.range.end = state->current;
-  state->start = state->current;
+  t.range.start = lexer->start;
+  t.range.end = lexer->current;
+  lexer->start = lexer->current;
   if (type != tTRIVIA) {
-    state->first_token_of_line = false;
+    lexer->first_token_of_line = false;
   }
 
   return t;
 }
 
-rbs_token_t rbs_next_eof_token(rbs_lexer_t *state) {
-  if ((size_t) state->current.byte_pos == rbs_string_len(state->string) + 1) {
+rbs_token_t rbs_next_eof_token(rbs_lexer_t *lexer) {
+  if ((size_t) lexer->current.byte_pos == rbs_string_len(lexer->string) + 1) {
     // End of String
     rbs_token_t t;
     t.type = pEOF;
-    t.range.start = state->start;
-    t.range.end = state->start;
-    state->start = state->current;
+    t.range.start = lexer->start;
+    t.range.end = lexer->start;
+    lexer->start = lexer->current;
 
     return t;
   } else {
     // NULL byte in the middle of the string
-    return rbs_next_token(state, pEOF);
+    return rbs_next_token(lexer, pEOF);
   }
 }
 
-void rbs_skip(rbs_lexer_t *state) {
-  if (!state->last_char) {
-    rbs_peek(state);
+void rbs_skip(rbs_lexer_t *lexer) {
+  if (!lexer->last_char) {
+    rbs_peek(lexer);
   }
 
   size_t byte_len;
 
-  if (state->last_char == '\0') {
+  if (lexer->last_char == '\0') {
     byte_len = 1;
   } else {
-    const char *start = state->string.start + state->current.byte_pos;
-    byte_len = state->encoding->char_width((const uint8_t *) start, (ptrdiff_t) (state->string.end - start));
+    const char *start = lexer->string.start + lexer->current.byte_pos;
+    byte_len = lexer->encoding->char_width((const uint8_t *) start, (ptrdiff_t) (lexer->string.end - start));
   }
 
-  state->current.char_pos += 1;
-  state->current.byte_pos += byte_len;
+  lexer->current.char_pos += 1;
+  lexer->current.byte_pos += byte_len;
 
-  if (state->last_char == '\n') {
-    state->current.line += 1;
-    state->current.column = 0;
-    state->first_token_of_line = true;
+  if (lexer->last_char == '\n') {
+    lexer->current.line += 1;
+    lexer->current.column = 0;
+    lexer->first_token_of_line = true;
   } else {
-    state->current.column += 1;
+    lexer->current.column += 1;
   }
 }
 
-void rbs_skipn(rbs_lexer_t *state, size_t size) {
+void rbs_skipn(rbs_lexer_t *lexer, size_t size) {
   for (size_t i = 0; i < size; i ++) {
-    rbs_peek(state);
-    rbs_skip(state);
+    rbs_peek(lexer);
+    rbs_skip(lexer);
   }
 }
 
-char *rbs_peek_token(rbs_lexer_t *state, rbs_token_t tok) {
-  return (char *) state->string.start + tok.range.start.byte_pos;
+char *rbs_peek_token(rbs_lexer_t *lexer, rbs_token_t tok) {
+  return (char *) lexer->string.start + tok.range.start.byte_pos;
 }

--- a/src/lexstate.c
+++ b/src/lexstate.c
@@ -104,7 +104,7 @@ int rbs_token_bytes(rbs_token_t tok) {
   return RBS_RANGE_BYTES(tok.range);
 }
 
-unsigned int rbs_peek(lexstate *state) {
+unsigned int rbs_peek(rbs_lexer_t *state) {
   if (state->current.char_pos == state->end_pos) {
     state->last_char = '\0';
     return 0;
@@ -119,7 +119,7 @@ unsigned int rbs_peek(lexstate *state) {
   }
 }
 
-rbs_token_t rbs_next_token(lexstate *state, enum RBSTokenType type) {
+rbs_token_t rbs_next_token(rbs_lexer_t *state, enum RBSTokenType type) {
   rbs_token_t t;
 
   t.type = type;
@@ -133,7 +133,7 @@ rbs_token_t rbs_next_token(lexstate *state, enum RBSTokenType type) {
   return t;
 }
 
-rbs_token_t rbs_next_eof_token(lexstate *state) {
+rbs_token_t rbs_next_eof_token(rbs_lexer_t *state) {
   if ((size_t) state->current.byte_pos == rbs_string_len(state->string) + 1) {
     // End of String
     rbs_token_t t;
@@ -149,7 +149,7 @@ rbs_token_t rbs_next_eof_token(lexstate *state) {
   }
 }
 
-void rbs_skip(lexstate *state) {
+void rbs_skip(rbs_lexer_t *state) {
   if (!state->last_char) {
     rbs_peek(state);
   }
@@ -175,13 +175,13 @@ void rbs_skip(lexstate *state) {
   }
 }
 
-void rbs_skipn(lexstate *state, size_t size) {
+void rbs_skipn(rbs_lexer_t *state, size_t size) {
   for (size_t i = 0; i < size; i ++) {
     rbs_peek(state);
     rbs_skip(state);
   }
 }
 
-char *rbs_peek_token(lexstate *state, rbs_token_t tok) {
+char *rbs_peek_token(rbs_lexer_t *state, rbs_token_t tok) {
   return (char *) state->string.start + tok.range.start.byte_pos;
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -22,9 +22,9 @@
 #define INTERN_TOKEN(parser, tok)                       \
   rbs_constant_pool_insert_shared_with_encoding(             \
     &parser->constant_pool,                             \
-    (const uint8_t *) rbs_peek_token(parser->lexstate, tok),\
+    (const uint8_t *) rbs_peek_token(parser->rbs_lexer_t, tok),\
     rbs_token_bytes(tok),                                        \
-    (void *) parser->lexstate->encoding                 \
+    (void *) parser->rbs_lexer_t->encoding                 \
   )
 
 #define KEYWORD_CASES \
@@ -124,7 +124,7 @@ static bool parse_simple(rbs_parser_t *parser, rbs_node_t **type);
 static rbs_string_t rbs_parser_peek_current_token(rbs_parser_t *parser) {
   rbs_range_t rg = parser->current_token.range;
 
-  const char *start = parser->lexstate->string.start + rg.start.byte_pos;
+  const char *start = parser->rbs_lexer_t->string.start + rg.start.byte_pos;
   size_t length = rg.end.byte_pos - rg.start.byte_pos;
 
   return rbs_string_new(start, start + length);
@@ -334,9 +334,9 @@ static bool parse_function_param(rbs_parser_t *parser, rbs_types_function_param_
 static rbs_constant_id_t intern_token_start_end(rbs_parser_t *parser, rbs_token_t start_token, rbs_token_t end_token) {
   return rbs_constant_pool_insert_shared_with_encoding(
     &parser->constant_pool,
-    (const uint8_t *) rbs_peek_token(parser->lexstate, start_token),
+    (const uint8_t *) rbs_peek_token(parser->rbs_lexer_t, start_token),
     end_token.range.end.byte_pos - start_token.range.start.byte_pos,
-    parser->lexstate->encoding
+    parser->rbs_lexer_t->encoding
   );
 }
 
@@ -898,7 +898,7 @@ static bool parse_record_attributes(rbs_parser_t *parser, rbs_hash_t **fields) {
 */
 NODISCARD
 static bool parse_symbol(rbs_parser_t *parser, rbs_location_t *location, rbs_types_literal_t **symbol) {
-  size_t offset_bytes = parser->lexstate->encoding->char_width((const uint8_t *) ":", (size_t) 1);
+  size_t offset_bytes = parser->rbs_lexer_t->encoding->char_width((const uint8_t *) ":", (size_t) 1);
   size_t bytes = rbs_token_bytes(parser->current_token) - offset_bytes;
 
   rbs_ast_symbol_t *literal;
@@ -908,7 +908,7 @@ static bool parse_symbol(rbs_parser_t *parser, rbs_location_t *location, rbs_typ
   case tSYMBOL: {
     rbs_location_t *symbolLoc = rbs_location_current_token(parser);
 
-    char *buffer = rbs_peek_token(parser->lexstate, parser->current_token);
+    char *buffer = rbs_peek_token(parser->rbs_lexer_t, parser->current_token);
     rbs_constant_id_t constant_id = rbs_constant_pool_insert_shared(
       &parser->constant_pool,
       (const uint8_t *) buffer+offset_bytes,
@@ -1162,7 +1162,7 @@ static bool parse_simple(rbs_parser_t *parser, rbs_node_t **type) {
     return true;
   }
   case tUIDENT: {
-    const char *name_str = rbs_peek_token(parser->lexstate, parser->current_token);
+    const char *name_str = rbs_peek_token(parser->rbs_lexer_t, parser->current_token);
     size_t name_len = rbs_token_bytes(parser->current_token);
 
     rbs_constant_id_t name = rbs_constant_pool_find(&parser->constant_pool, (const uint8_t *) name_str, name_len);
@@ -1588,12 +1588,12 @@ static bool parse_annotation(rbs_parser_t *parser, rbs_ast_annotation_t **annota
   rbs_range_t rg = parser->current_token.range;
 
   size_t offset_bytes =
-    parser->lexstate->encoding->char_width((const uint8_t *) "%", (size_t) 1) +
-    parser->lexstate->encoding->char_width((const uint8_t *) "a", (size_t) 1);
+    parser->rbs_lexer_t->encoding->char_width((const uint8_t *) "%", (size_t) 1) +
+    parser->rbs_lexer_t->encoding->char_width((const uint8_t *) "a", (size_t) 1);
 
   rbs_string_t str = rbs_string_new(
-    parser->lexstate->string.start + rg.start.byte_pos + offset_bytes,
-    parser->lexstate->string.end
+    parser->rbs_lexer_t->string.start + rg.start.byte_pos + offset_bytes,
+    parser->rbs_lexer_t->string.end
   );
   unsigned int open_char = rbs_utf8_string_to_codepoint(str);
 
@@ -1620,8 +1620,8 @@ static bool parse_annotation(rbs_parser_t *parser, rbs_ast_annotation_t **annota
     return false;
   }
 
-  size_t open_bytes = parser->lexstate->encoding->char_width((const uint8_t *) &open_char, (size_t) 1);
-  size_t close_bytes = parser->lexstate->encoding->char_width((const uint8_t *) &close_char, (size_t) 1);
+  size_t open_bytes = parser->rbs_lexer_t->encoding->char_width((const uint8_t *) &open_char, (size_t) 1);
+  size_t close_bytes = parser->rbs_lexer_t->encoding->char_width((const uint8_t *) &close_char, (size_t) 1);
 
   rbs_string_t current_token = rbs_parser_peek_current_token(parser);
   size_t total_offset = offset_bytes + open_bytes;
@@ -1686,9 +1686,9 @@ static bool parse_method_name(rbs_parser_t *parser, rbs_range_t *range, rbs_ast_
 
       rbs_constant_id_t constant_id = rbs_constant_pool_insert_shared_with_encoding(
         &parser->constant_pool,
-        (const uint8_t *) parser->lexstate->string.start + range->start.byte_pos,
+        (const uint8_t *) parser->rbs_lexer_t->string.start + range->start.byte_pos,
         range->end.byte_pos - range->start.byte_pos,
-        parser->lexstate->encoding
+        parser->rbs_lexer_t->encoding
       );
 
       rbs_location_t *symbolLoc = rbs_location_new(&parser->allocator, *range);
@@ -3100,8 +3100,8 @@ static bool parse_use_directive(rbs_parser_t *parser, rbs_ast_directives_use_t *
 }
 
 static rbs_ast_comment_t *parse_comment_lines(rbs_parser_t *parser, rbs_comment_t *com) {
-  size_t hash_bytes = parser->lexstate->encoding->char_width((const uint8_t *) "#", (size_t) 1);
-  size_t space_bytes = parser->lexstate->encoding->char_width((const uint8_t *) " ", (size_t) 1);
+  size_t hash_bytes = parser->rbs_lexer_t->encoding->char_width((const uint8_t *) "#", (size_t) 1);
+  size_t space_bytes = parser->rbs_lexer_t->encoding->char_width((const uint8_t *) " ", (size_t) 1);
 
   rbs_buffer_t rbs_buffer;
   rbs_buffer_init(&parser->allocator, &rbs_buffer);
@@ -3109,12 +3109,12 @@ static rbs_ast_comment_t *parse_comment_lines(rbs_parser_t *parser, rbs_comment_
   for (size_t i = 0; i < com->line_count; i++) {
     rbs_token_t tok = com->tokens[i];
 
-    const char *comment_start = parser->lexstate->string.start + tok.range.start.byte_pos + hash_bytes;
+    const char *comment_start = parser->rbs_lexer_t->string.start + tok.range.start.byte_pos + hash_bytes;
     size_t comment_bytes = RBS_RANGE_BYTES(tok.range) - hash_bytes;
 
     rbs_string_t str = rbs_string_new(
       comment_start,
-      parser->lexstate->string.end
+      parser->rbs_lexer_t->string.end
     );
     unsigned char c = rbs_utf8_string_to_codepoint(str);
 
@@ -3311,7 +3311,7 @@ void rbs_parser_advance(rbs_parser_t *parser) {
       break;
     }
 
-    parser->next_token3 = rbsparser_next_token(parser->lexstate);
+    parser->next_token3 = rbsparser_next_token(parser->rbs_lexer_t);
 
     if (parser->next_token3.type == tCOMMENT) {
       // skip
@@ -3346,8 +3346,8 @@ rbs_ast_comment_t *rbs_parser_get_comment(rbs_parser_t *parser, int subject_line
   }
 }
 
-lexstate *rbs_lexer_new(rbs_allocator_t *allocator, rbs_string_t string, const rbs_encoding_t *encoding, int start_pos, int end_pos) {
-  lexstate *lexer = rbs_allocator_alloc(allocator, lexstate);
+rbs_lexer_t *rbs_lexer_new(rbs_allocator_t *allocator, rbs_string_t string, const rbs_encoding_t *encoding, int start_pos, int end_pos) {
+  rbs_lexer_t *lexer = rbs_allocator_alloc(allocator, rbs_lexer_t);
 
   rbs_position_t start_position = (rbs_position_t) {
     .byte_pos = 0,
@@ -3356,7 +3356,7 @@ lexstate *rbs_lexer_new(rbs_allocator_t *allocator, rbs_string_t string, const r
     .column = 0,
   };
 
-  *lexer = (lexstate) {
+  *lexer = (rbs_lexer_t) {
     .string = string,
     .start_pos = start_pos,
     .end_pos = end_pos,
@@ -3378,11 +3378,11 @@ rbs_parser_t *rbs_parser_new(rbs_string_t string, const rbs_encoding_t *encoding
   rbs_allocator_t allocator;
   rbs_allocator_init(&allocator);
 
-  lexstate *lexer = rbs_lexer_new(&allocator, string, encoding, start_pos, end_pos);
+  rbs_lexer_t *lexer = rbs_lexer_new(&allocator, string, encoding, start_pos, end_pos);
   rbs_parser_t *parser = rbs_allocator_alloc(&allocator, rbs_parser_t);
 
   *parser = (rbs_parser_t) {
-    .lexstate = lexer,
+    .rbs_lexer_t = lexer,
 
     .current_token = NullToken,
     .next_token = NullToken,

--- a/src/parser.c
+++ b/src/parser.c
@@ -3311,7 +3311,7 @@ void rbs_parser_advance(rbs_parser_t *parser) {
       break;
     }
 
-    parser->next_token3 = rbsparser_next_token(parser->rbs_lexer_t);
+    parser->next_token3 = rbs_lexer_next_token(parser->rbs_lexer_t);
 
     if (parser->next_token3.type == tCOMMENT) {
       // skip


### PR DESCRIPTION
1. `lexerstate` should be `rbs_lexer_t` instead
2. Params representing `rbs_lexer_t` should be named `lexer` instead of `state`
3. `rbsparser_next_token` should be called `rbs_lexer_next_token`

After this PR, all structs & functions we want to expose should have `rbs_` prefix.