### PR TITLE
Always define the `is_power_of_two` function

### DIFF
--- a/src/util/rbs_constant_pool.c
+++ b/src/util/rbs_constant_pool.c
@@ -37,12 +37,9 @@ next_power_of_two(uint32_t v) {
     return v;
 }
 
-#ifndef NDEBUG
-static bool
-is_power_of_two(uint32_t size) {
+static bool is_power_of_two(uint32_t size) {
     return (size & (size - 1)) == 0;
 }
-#endif
 
 /**
  * Resize a constant pool to a given capacity.


### PR DESCRIPTION
It was only used in `assert` macros, so it only needs to be defined in debug mode. But since `rbs_assert` is a function, `is_power_of_two` always needs to be defined.

Without this change, Sorbet fails to build with `c-api`.