### PR TITLE
Use one big arena for lexer/parser allocations

### DIFF
--- a/ext/rbs_extension/main.c
+++ b/ext/rbs_extension/main.c
@@ -14,7 +14,6 @@ Init_rbs_extension(void)
 #ifdef HAVE_RB_EXT_RACTOR_SAFE
   rb_ext_ractor_safe(true);
 #endif
-  rbs__init_arena_allocator();
   rbs__init_constants();
   rbs__init_location();
   rbs__init_parser();

--- a/ext/rbs_extension/main.c
+++ b/ext/rbs_extension/main.c
@@ -1,6 +1,6 @@
 #include "rbs_extension.h"
+#include "rbs/util/rbs_allocator.h"
 #include "rbs/util/rbs_constant_pool.h"
-
 #include "ruby/vm.h"
 
 static
@@ -14,6 +14,7 @@ Init_rbs_extension(void)
 #ifdef HAVE_RB_EXT_RACTOR_SAFE
   rb_ext_ractor_safe(true);
 #endif
+  rbs__init_arena_allocator();
   rbs__init_constants();
   rbs__init_location();
   rbs__init_parser();

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2939,9 +2939,12 @@ static VALUE
 rbsparser_lex(VALUE self, VALUE buffer, VALUE end_pos) {
   VALUE string = rb_funcall(buffer, rb_intern("content"), 0);
   StringValue(string);
-  lexstate *lexer = alloc_lexer(string, 0, FIX2INT(end_pos));
-  VALUE results = rb_ary_new();
 
+  rbs_allocator_t allocator;
+  rbs_allocator_init(&allocator);
+  lexstate *lexer = alloc_lexer(&allocator, string, 0, FIX2INT(end_pos));
+
+  VALUE results = rb_ary_new();
   token token = NullToken;
   while (token.type != pEOF) {
     token = rbsparser_next_token(lexer);
@@ -2951,7 +2954,7 @@ rbsparser_lex(VALUE self, VALUE buffer, VALUE end_pos) {
     rb_ary_push(results, pair);
   }
 
-  free(lexer);
+  rbs_allocator_free(&allocator);
 
   return results;
 }

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2941,7 +2941,7 @@ rbsparser_lex(VALUE self, VALUE buffer, VALUE end_pos) {
   StringValue(string);
 
   rbs_allocator_t allocator;
-  rbs_allocator_init(&allocator);
+  rbs_allocator_init(&allocator, rbs_allocator_default_mem());
   lexstate *lexer = alloc_lexer(&allocator, string, 0, FIX2INT(end_pos));
 
   VALUE results = rb_ary_new();

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2882,8 +2882,7 @@ rbsparser_parse_type(VALUE self, VALUE buffer, VALUE start_pos, VALUE end_pos, V
 {
   VALUE string = rb_funcall(buffer, rb_intern("content"), 0);
   StringValue(string);
-  lexstate *lexer = alloc_lexer(string, FIX2INT(start_pos), FIX2INT(end_pos));
-  parserstate *parser = alloc_parser(buffer, lexer, FIX2INT(start_pos), FIX2INT(end_pos), variables);
+  parserstate *parser = alloc_parser(buffer, string, FIX2INT(start_pos), FIX2INT(end_pos), variables);
   struct parse_type_arg arg = {
     parser,
     require_eof
@@ -2913,8 +2912,7 @@ rbsparser_parse_method_type(VALUE self, VALUE buffer, VALUE start_pos, VALUE end
 {
   VALUE string = rb_funcall(buffer, rb_intern("content"), 0);
   StringValue(string);
-  lexstate *lexer = alloc_lexer(string, FIX2INT(start_pos), FIX2INT(end_pos));
-  parserstate *parser = alloc_parser(buffer, lexer, FIX2INT(start_pos), FIX2INT(end_pos), variables);
+  parserstate *parser = alloc_parser(buffer, string, FIX2INT(start_pos), FIX2INT(end_pos), variables);
   struct parse_type_arg arg = {
     parser,
     require_eof
@@ -2933,8 +2931,7 @@ rbsparser_parse_signature(VALUE self, VALUE buffer, VALUE start_pos, VALUE end_p
 {
   VALUE string = rb_funcall(buffer, rb_intern("content"), 0);
   StringValue(string);
-  lexstate *lexer = alloc_lexer(string, FIX2INT(start_pos), FIX2INT(end_pos));
-  parserstate *parser = alloc_parser(buffer, lexer, FIX2INT(start_pos), FIX2INT(end_pos), Qnil);
+  parserstate *parser = alloc_parser(buffer, string, FIX2INT(start_pos), FIX2INT(end_pos), Qnil);
   return rb_ensure(parse_signature_try, (VALUE)parser, ensure_free_parser, (VALUE)parser);
 }
 

--- a/ext/rbs_extension/parserstate.c
+++ b/ext/rbs_extension/parserstate.c
@@ -319,7 +319,8 @@ lexstate *alloc_lexer(VALUE string, int start_pos, int end_pos) {
   return lexer;
 }
 
-parserstate *alloc_parser(VALUE buffer, lexstate *lexer, int start_pos, int end_pos, VALUE variables) {
+parserstate *alloc_parser(VALUE buffer, VALUE string, int start_pos, int end_pos, VALUE variables) {
+  lexstate *lexer = alloc_lexer(string, start_pos, end_pos);
   parserstate *parser = malloc(sizeof(parserstate));
 
   *parser = (parserstate) {

--- a/ext/rbs_extension/parserstate.c
+++ b/ext/rbs_extension/parserstate.c
@@ -306,7 +306,7 @@ lexstate *alloc_lexer(rbs_allocator_t *allocator, VALUE string, int start_pos, i
 
 parserstate *alloc_parser(VALUE buffer, VALUE string, int start_pos, int end_pos, VALUE variables) {
   rbs_allocator_t allocator;
-  rbs_allocator_init(&allocator);
+  rbs_allocator_init(&allocator, rbs_allocator_default_mem());
 
   lexstate *lexer = alloc_lexer(&allocator, string, start_pos, end_pos);
   parserstate *parser = rbs_allocator_alloc(&allocator, parserstate);

--- a/ext/rbs_extension/parserstate.h
+++ b/ext/rbs_extension/parserstate.h
@@ -109,11 +109,11 @@ lexstate *alloc_lexer(VALUE string, int start_pos, int end_pos);
  * Allocate new parserstate object.
  *
  * ```
- * alloc_parser(buffer, lexer, 0, 1, variables)    // New parserstate with variables
- * alloc_parser(buffer, lexer, 3, 5, Qnil)         // New parserstate without variables
+ * alloc_parser(buffer, VALUE string, 0, 1, variables)    // New parserstate with variables
+ * alloc_parser(buffer, VALUE string, 3, 5, Qnil)         // New parserstate without variables
  * ```
  * */
-parserstate *alloc_parser(VALUE buffer, lexstate *lexer, int start_pos, int end_pos, VALUE variables);
+parserstate *alloc_parser(VALUE buffer, VALUE string, int start_pos, int end_pos, VALUE variables);
 void free_parser(parserstate *parser);
 /**
  * Advance one token.

--- a/ext/rbs_extension/parserstate.h
+++ b/ext/rbs_extension/parserstate.h
@@ -3,6 +3,8 @@
 
 #include <stdbool.h>
 
+#include "rbs/util/rbs_allocator.h"
+#include "rbs/util/rbs_constant_pool.h"
 #include "lexer.h"
 #include "location.h"
 
@@ -57,11 +59,11 @@ typedef struct {
   comment *last_comment;  /* Last read comment */
 
   rbs_constant_pool_t constant_pool;
+  rbs_allocator_t allocator;
 } parserstate;
 
-comment *alloc_comment(token comment_token, comment *last_comment);
-void free_comment(comment *com);
-void comment_insert_new_line(comment *com, token comment_token);
+comment *alloc_comment(rbs_allocator_t *, token comment_token, comment *last_comment);
+void comment_insert_new_line(rbs_allocator_t *, comment *com, token comment_token);
 comment *comment_get_comment(comment *com, int line);
 VALUE comment_to_ruby(comment *com, VALUE buffer);
 
@@ -103,7 +105,7 @@ bool parser_typevar_member(parserstate *state, rbs_constant_id_t id);
  * alloc_lexer(string, 0, 31)    // New lexstate with buffer content
  * ```
  * */
-lexstate *alloc_lexer(VALUE string, int start_pos, int end_pos);
+lexstate *alloc_lexer(rbs_allocator_t *, VALUE string, int start_pos, int end_pos);
 
 /**
  * Allocate new parserstate object.

--- a/include/rbs/util/rbs_allocator.h
+++ b/include/rbs/util/rbs_allocator.h
@@ -1,0 +1,21 @@
+#ifndef RBS_ALLOCATOR_H
+#define RBS_ALLOCATOR_H
+
+#include <stddef.h>
+
+typedef struct rbs_allocator {
+    // The head of a linked list of pages, starting with the most recently allocated page.
+    struct rbs_allocator_page *page;
+} rbs_allocator_t;
+
+void rbs_allocator_init(rbs_allocator_t *);
+void rbs_allocator_free(rbs_allocator_t *);
+void *rbs_allocator_malloc_impl(rbs_allocator_t *, /*    1    */ size_t size, size_t alignment);
+void *rbs_allocator_calloc_impl(rbs_allocator_t *, size_t count, size_t size, size_t alignment);
+
+#define rbs_allocator_alloc(allocator, type)         ((type *) rbs_allocator_malloc_impl((allocator),          sizeof(type), alignof(type)))
+#define rbs_allocator_calloc(allocator, count, type) ((type *) rbs_allocator_calloc_impl((allocator), (count), sizeof(type), alignof(type)))
+
+void rbs__init_arena_allocator(void);
+
+#endif

--- a/include/rbs/util/rbs_allocator.h
+++ b/include/rbs/util/rbs_allocator.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <inttypes.h>
+#include <stdalign.h>
 
 typedef struct rbs_allocator {
     uintptr_t start;

--- a/include/rbs/util/rbs_allocator.h
+++ b/include/rbs/util/rbs_allocator.h
@@ -2,20 +2,21 @@
 #define RBS_ALLOCATOR_H
 
 #include <stddef.h>
+#include <inttypes.h>
 
 typedef struct rbs_allocator {
-    // The head of a linked list of pages, starting with the most recently allocated page.
-    struct rbs_allocator_page *page;
+    uintptr_t start;
+    uintptr_t end;
+    uintptr_t heap_ptr;
 } rbs_allocator_t;
 
-void rbs_allocator_init(rbs_allocator_t *);
+size_t rbs_allocator_default_mem(void);
+void rbs_allocator_init(rbs_allocator_t *, size_t size);
 void rbs_allocator_free(rbs_allocator_t *);
 void *rbs_allocator_malloc_impl(rbs_allocator_t *, /*    1    */ size_t size, size_t alignment);
 void *rbs_allocator_calloc_impl(rbs_allocator_t *, size_t count, size_t size, size_t alignment);
 
 #define rbs_allocator_alloc(allocator, type)         ((type *) rbs_allocator_malloc_impl((allocator),          sizeof(type), alignof(type)))
 #define rbs_allocator_calloc(allocator, count, type) ((type *) rbs_allocator_calloc_impl((allocator), (count), sizeof(type), alignof(type)))
-
-void rbs__init_arena_allocator(void);
 
 #endif

--- a/src/util/rbs_allocator.c
+++ b/src/util/rbs_allocator.c
@@ -105,20 +105,21 @@ void rbs_allocator_init(rbs_allocator_t *allocator, size_t size) {
     void* mem = map_memory(size + page_size);
     // Guard page; remove range checks in alloc fast path and hard fail if we
     // consume all memory
-    void* last_page = (char*)mem + size;
-    assert(is_page_aligned((uintptr_t)mem + size));
+    void* last_page = (char *) mem + size;
     guard_page(last_page, page_size);
-    uintptr_t start = (uintptr_t)mem;
+    uintptr_t start = (uintptr_t) mem;
+    uintptr_t end = start + size;
+    assert(is_page_aligned(end));
     *allocator = (rbs_allocator_t) {
       .start = start,
       .heap_ptr = start,
-      .end = start + size,
+      .end = end,
     };
 }
 
 void rbs_allocator_free(rbs_allocator_t *allocator) {
   if (allocator->start == 0) { return; }
-    destroy_memory((void*)allocator->start, allocator->end - allocator->start);
+    destroy_memory((void *) allocator->start, allocator->end - allocator->start);
     *allocator = (rbs_allocator_t) {
       .start = 0,
       .heap_ptr = 0,
@@ -131,7 +132,7 @@ void *rbs_allocator_malloc_impl(rbs_allocator_t *allocator, size_t size, size_t 
     assert(size % alignment == 0 && "size must be a multiple of the alignment");
     uintptr_t aligned = align(allocator->heap_ptr, alignment);
     allocator->heap_ptr = aligned + size;
-    return (void*)aligned;
+    return (void *) aligned;
 }
 
 // Note: This will eagerly fill with zeroes, unlike `calloc()` which can map a page in a page to be zeroed lazily.

--- a/src/util/rbs_allocator.c
+++ b/src/util/rbs_allocator.c
@@ -1,0 +1,184 @@
+/**
+ *  @file rbs_allocator.c
+ *
+ *  A simple arena allocator that can be freed all at once.
+ *
+ *  This allocator maintains a linked list of pages, which come in two flavours:
+ *      1. Small allocation pages, which are the same size as the system page size.
+ *      2. Large allocation pages, which are the exact size requested, for sizes greater than the small page size.
+ *
+ *  Small allocations always fit into the unused space at the end of the "head" page. If there isn't enough room, a new
+ *  page is allocated, and the small allocation is placed at its start. This approach wastes that unused slack at the
+ *  end of the previous page, but it means that allocations are instant and never scan the linked list to find a gap.
+ *
+ *  This allocator doesn't support freeing individual allocations. Only the whole arena can be freed at once at the end.
+ */
+
+#include "rbs/util/rbs_allocator.h"
+
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h> // for memset()
+
+#ifdef _WIN32
+    #include <windows.h>
+#else
+    #include <unistd.h>
+    #include <sys/types.h>
+#endif
+
+typedef struct rbs_allocator_page {
+    uint32_t payload_size;
+
+    // The offset of the next available byte.
+    uint32_t offset;
+
+    // The previously allocated page, or NULL if this is the first page.
+    struct rbs_allocator_page *next;
+
+    // The variably-sized payload of the page.
+    char payload[];
+} rbs_allocator_page_t;
+
+// This allocator's normal pages have the same size as the system memory pages, consisting of a fixed-size header
+// (sizeof(rbs_allocator_page_t)) followed `default_page_payload_size`  bytes of payload.
+// TODO: When we have real-world usage data, we can tune this to use a smaller number of larger pages.
+static size_t default_page_payload_size = 0;
+static uint32_t large_page_flag = UINT32_MAX;
+
+static size_t get_system_page_size() {
+#ifdef _WIN32
+    SYSTEM_INFO si;
+    GetSystemInfo(&si);
+    return si.dwPageSize;
+#else
+    long sz = sysconf(_SC_PAGESIZE);
+    if (sz == -1) return 4096; // Fallback to the common 4KB page size
+    return (size_t) sz;
+#endif
+}
+
+void rbs__init_arena_allocator(void) {
+    const size_t system_page_size = get_system_page_size();
+
+    // The size of a struct that ends with a flexible array member is the size of the struct without the
+    // flexible array member. https://en.wikipedia.org/wiki/Flexible_array_member#Effect_on_struct_size_and_padding
+    const size_t page_header_size = sizeof(rbs_allocator_page_t);
+    default_page_payload_size = system_page_size - page_header_size;
+}
+
+// Returns the number of bytes needed to pad the given pointer up to the nearest multiple of the given `alignment`.
+static size_t needed_padding(void *ptr, size_t alignment) {
+    const uintptr_t addr = (uintptr_t) ptr;
+    const uintptr_t aligned_addr = (addr + (alignment - 1)) & -alignment;
+    return (aligned_addr - addr);
+}
+
+static rbs_allocator_page_t *rbs_allocator_page_new(size_t payload_size) {
+    const size_t page_header_size = sizeof(rbs_allocator_page_t);
+
+    rbs_allocator_page_t *page = calloc(1, page_header_size + payload_size);
+    *page = (rbs_allocator_page_t) {
+        .payload_size = (uint32_t) payload_size,
+        .offset = page_header_size,
+        .next = NULL,
+    };
+    return page;
+}
+
+static rbs_allocator_page_t *rbs_allocator_page_new_default(void) {
+    return rbs_allocator_page_new(default_page_payload_size);
+}
+
+static rbs_allocator_page_t *rbs_allocator_page_new_large(size_t payload_size) {
+    rbs_allocator_page_t *page = rbs_allocator_page_new(payload_size);
+
+    page->offset = large_page_flag;
+
+    return page;
+}
+
+// Attempts to allocate `size` bytes from `page`, returning NULL if there is insufficient space.
+static void *rbs_allocator_page_attempt_alloc(rbs_allocator_page_t *page, size_t size, size_t alignment) {
+    const size_t alignment_padding = needed_padding(page->payload + page->offset, alignment);
+
+    const size_t remaining_size = page->payload_size - page->offset;
+    const size_t needed_size = alignment_padding + size;
+    if (remaining_size < needed_size) return NULL; // Not enough space in this page.
+
+    void *ptr = page->payload + page->offset + alignment_padding;
+    page->offset += needed_size;
+    return ptr;
+}
+
+void rbs_allocator_init(rbs_allocator_t *allocator) {
+    *allocator = (rbs_allocator_t) {
+        .page = rbs_allocator_page_new_default(),
+    };
+}
+
+void rbs_allocator_free(rbs_allocator_t *allocator) {
+    rbs_allocator_page_t *page = allocator->page;
+    while (page) {
+        rbs_allocator_page_t *next = page->next;
+        free(page);
+        page = next;
+    }
+
+    *allocator = (rbs_allocator_t) {
+        .page = NULL,
+    };
+}
+
+// Allocates `size` bytes from `allocator`, aligned to an `alignment`-byte boundary.
+void *rbs_allocator_malloc_impl(rbs_allocator_t *allocator, size_t size, size_t alignment) {
+    assert(size % alignment == 0 && "size must be a multiple of the alignment");
+
+    if (default_page_payload_size < size) { // Big allocation, give it its own page.
+        // How much we need to pad the new page's payload in order to get an aligned pointer
+        // hack?
+        const size_t alignment_padding = needed_padding((void *) (sizeof(rbs_allocator_page_t) + size), alignment);
+
+        rbs_allocator_page_t *new_page = rbs_allocator_page_new_large(alignment_padding + size);
+
+        // This simple allocator can only put small allocations into the head page.
+        // Naively prepending this large allocation page to the head of the allocator before the previous head page
+        // would waste the remaining space in the head page.
+        // So instead, we'll splice in the large page *after* the head page.
+        //
+        // +-------+    +-----------+        +-----------+
+        // | arena |    | head page |        | new_page  |
+        // |-------|    |-----------+        |-----------+
+        // | *page |--->|  size     |   +--->|  size     |   +---> ... previous tail
+        // +-------+    |  offset   |   |    |  offset   |   |
+        //              | *next ----+---+    | *next ----+---+
+        //              |    ...    |        |    ...    |
+        //              +-----------+        +-----------+
+        //
+        new_page->next = allocator->page->next;
+        allocator->page->next = new_page;
+
+        return new_page->payload + alignment_padding;
+    }
+
+    void *p = rbs_allocator_page_attempt_alloc(allocator->page, size, alignment);
+    if (p != NULL) return p;
+
+    // Not enough space. Allocate a new page and prepend it to the allocator's linked list.
+    rbs_allocator_page_t *new_page = rbs_allocator_page_new_default();
+    new_page->next = allocator->page;
+    allocator->page = new_page;
+
+    p = rbs_allocator_page_attempt_alloc(new_page, size, alignment);
+    assert(p != NULL && "Failed to allocate a new allocator page");
+    return p;
+}
+
+// Note: This will eagerly fill with zeroes, unlike `calloc()` which can map a page in a page to be zeroed lazily.
+//       It's assumed that callers to this function will immediately write to the allocated memory, anyway.
+void *rbs_allocator_calloc_impl(rbs_allocator_t *allocator, size_t count, size_t size, size_t alignment) {
+    void *p = rbs_allocator_malloc_impl(allocator, count * size, alignment);
+    memset(p, 0, count * size);
+    return p;
+}
+

--- a/src/util/rbs_allocator.c
+++ b/src/util/rbs_allocator.c
@@ -117,6 +117,7 @@ void rbs_allocator_init(rbs_allocator_t *allocator, size_t size) {
 }
 
 void rbs_allocator_free(rbs_allocator_t *allocator) {
+  if (allocator->start == 0) { return; }
     destroy_memory((void*)allocator->start, allocator->end - allocator->start);
     *allocator = (rbs_allocator_t) {
       .start = 0,


### PR DESCRIPTION
- **Allocate lexer inside `alloc_parser()`**
- **Add new arena allocator**
- **Use one massive slice of virtual memory per arena**
- **Exit early if freeing something that has been freed before**
- **Fix cast style**
