### PR TITLE
Remove unnecessary freeing functions

### DIFF
--- a/ext/rbs_extension/main.c
+++ b/ext/rbs_extension/main.c
@@ -125,7 +125,6 @@ static VALUE parse_type_try(VALUE a) {
 
 
   VALUE ruby_ast = rbs_struct_to_ruby_value(ctx, type);
-  rbs_node_destroy((rbs_node_t *) type);
   return ruby_ast;
 }
 
@@ -214,7 +213,6 @@ static VALUE parse_method_type_try(VALUE a) {
   );
 
   VALUE ruby_ast = rbs_struct_to_ruby_value(ctx, (rbs_node_t *) method_type);
-  rbs_node_destroy((rbs_node_t *) method_type);
   return ruby_ast;
 }
 
@@ -255,7 +253,6 @@ static VALUE parse_signature_try(VALUE a) {
   );
 
   VALUE ruby_ast = rbs_struct_to_ruby_value(ctx, (rbs_node_t *) signature);
-  rbs_node_destroy((rbs_node_t *) signature);
   return ruby_ast;
 }
 

--- a/ext/rbs_extension/main.c
+++ b/ext/rbs_extension/main.c
@@ -123,9 +123,7 @@ static VALUE parse_type_try(VALUE a) {
     arg->encoding
   );
 
-
-  VALUE ruby_ast = rbs_struct_to_ruby_value(ctx, type);
-  return ruby_ast;
+  return rbs_struct_to_ruby_value(ctx, type);
 }
 
 static rbs_lexer_t *alloc_lexer_from_buffer(rbs_allocator_t *allocator, VALUE string, rb_encoding *encoding, int start_pos, int end_pos) {
@@ -212,8 +210,7 @@ static VALUE parse_method_type_try(VALUE a) {
     arg->encoding
   );
 
-  VALUE ruby_ast = rbs_struct_to_ruby_value(ctx, (rbs_node_t *) method_type);
-  return ruby_ast;
+  return rbs_struct_to_ruby_value(ctx, (rbs_node_t *) method_type);
 }
 
 static VALUE rbsparser_parse_method_type(VALUE self, VALUE buffer, VALUE start_pos, VALUE end_pos, VALUE variables, VALUE require_eof) {
@@ -252,8 +249,7 @@ static VALUE parse_signature_try(VALUE a) {
     arg->encoding
   );
 
-  VALUE ruby_ast = rbs_struct_to_ruby_value(ctx, (rbs_node_t *) signature);
-  return ruby_ast;
+  return rbs_struct_to_ruby_value(ctx, (rbs_node_t *) signature);
 }
 
 static VALUE rbsparser_parse_signature(VALUE self, VALUE buffer, VALUE start_pos, VALUE end_pos) {

--- a/include/rbs/ast.h
+++ b/include/rbs/ast.h
@@ -685,6 +685,4 @@ rbs_types_union_t *rbs_types_union_new(rbs_allocator_t *allocator, rbs_location_
 rbs_types_untyped_function_t *rbs_types_untyped_function_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_t *return_type);
 rbs_types_variable_t *rbs_types_variable_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_ast_symbol_t *name);
 
-void rbs_node_destroy(rbs_node_t *any_node);
-
 #endif

--- a/src/ast.c
+++ b/src/ast.c
@@ -95,17 +95,6 @@ rbs_node_list_t* rbs_node_list_new(rbs_allocator_t *allocator) {
     return list;
 }
 
-void rbs_node_list_free(rbs_node_list_t *list) {
-    rbs_node_list_node_t *current = list->head;
-    while (current != NULL) {
-        rbs_node_list_node_t *next = current->next;
-        rbs_node_destroy(current->node);
-        // `current` is owned by the arena, so it will be freed automatically when the arena is freed.
-        current = next;
-    }
-    // `list` is owned by the arena, so it will be freed automatically when the arena is freed.
-}
-
 void rbs_node_list_append(rbs_node_list_t *list, rbs_node_t *node) {
     rbs_node_list_node_t *new_node = rbs_allocator_alloc(list->allocator, rbs_node_list_node_t);
     *new_node = (rbs_node_list_node_t) {
@@ -136,18 +125,6 @@ rbs_hash_t* rbs_hash_new(rbs_allocator_t *allocator) {
     };
 
     return hash;
-}
-
-void rbs_hash_free(rbs_hash_t *hash) {
-    rbs_hash_node_t *current = hash->head;
-    while (current != NULL) {
-        rbs_hash_node_t *next = current->next;
-        rbs_node_destroy(current->key);
-        rbs_node_destroy(current->value);
-        // `current` is owned by the arena, so it will be freed automatically when the arena is freed.
-        current = next;
-    }
-    // `hash` is owned by the arena, so it will be freed automatically when the arena is freed.
 }
 
 bool rbs_node_equal(rbs_node_t *lhs, rbs_node_t *rhs) {
@@ -238,7 +215,7 @@ rbs_ast_symbol_t *rbs_ast_symbol_new(rbs_allocator_t *allocator, rbs_location_t 
     return instance;
 }
 
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_annotation_t *rbs_ast_annotation_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_string_t string) {
     rbs_ast_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_annotation_t);
 
@@ -253,7 +230,7 @@ rbs_ast_annotation_t *rbs_ast_annotation_new(rbs_allocator_t *allocator, rbs_loc
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_bool_t *rbs_ast_bool_new(rbs_allocator_t *allocator, rbs_location_t *location, bool value) {
     rbs_ast_bool_t *instance = rbs_allocator_alloc(allocator, rbs_ast_bool_t);
 
@@ -268,7 +245,7 @@ rbs_ast_bool_t *rbs_ast_bool_new(rbs_allocator_t *allocator, rbs_location_t *loc
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_comment_t *rbs_ast_comment_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_string_t string) {
     rbs_ast_comment_t *instance = rbs_allocator_alloc(allocator, rbs_ast_comment_t);
 
@@ -283,7 +260,7 @@ rbs_ast_comment_t *rbs_ast_comment_new(rbs_allocator_t *allocator, rbs_location_
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_declarations_class_t *rbs_ast_declarations_class_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *name, rbs_node_list_t *type_params, rbs_ast_declarations_class_super_t *super_class, rbs_node_list_t *members, rbs_node_list_t *annotations, rbs_ast_comment_t *comment) {
     rbs_ast_declarations_class_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_class_t);
 
@@ -303,7 +280,7 @@ rbs_ast_declarations_class_t *rbs_ast_declarations_class_new(rbs_allocator_t *al
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_declarations_class_super_t *rbs_ast_declarations_class_super_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *name, rbs_node_list_t *args) {
     rbs_ast_declarations_class_super_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_class_super_t);
 
@@ -319,7 +296,7 @@ rbs_ast_declarations_class_super_t *rbs_ast_declarations_class_super_new(rbs_all
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_declarations_class_alias_t *rbs_ast_declarations_class_alias_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *new_name, rbs_type_name_t *old_name, rbs_ast_comment_t *comment, rbs_node_list_t *annotations) {
     rbs_ast_declarations_class_alias_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_class_alias_t);
 
@@ -337,7 +314,7 @@ rbs_ast_declarations_class_alias_t *rbs_ast_declarations_class_alias_new(rbs_all
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_declarations_constant_t *rbs_ast_declarations_constant_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *name, rbs_node_t *type, rbs_ast_comment_t *comment, rbs_node_list_t *annotations) {
     rbs_ast_declarations_constant_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_constant_t);
 
@@ -355,7 +332,7 @@ rbs_ast_declarations_constant_t *rbs_ast_declarations_constant_new(rbs_allocator
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_declarations_global_t *rbs_ast_declarations_global_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_ast_comment_t *comment, rbs_node_list_t *annotations) {
     rbs_ast_declarations_global_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_global_t);
 
@@ -373,7 +350,7 @@ rbs_ast_declarations_global_t *rbs_ast_declarations_global_new(rbs_allocator_t *
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_declarations_interface_t *rbs_ast_declarations_interface_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *name, rbs_node_list_t *type_params, rbs_node_list_t *members, rbs_node_list_t *annotations, rbs_ast_comment_t *comment) {
     rbs_ast_declarations_interface_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_interface_t);
 
@@ -392,7 +369,7 @@ rbs_ast_declarations_interface_t *rbs_ast_declarations_interface_new(rbs_allocat
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_declarations_module_t *rbs_ast_declarations_module_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *name, rbs_node_list_t *type_params, rbs_node_list_t *self_types, rbs_node_list_t *members, rbs_node_list_t *annotations, rbs_ast_comment_t *comment) {
     rbs_ast_declarations_module_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_module_t);
 
@@ -412,7 +389,7 @@ rbs_ast_declarations_module_t *rbs_ast_declarations_module_new(rbs_allocator_t *
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_declarations_module_self_t *rbs_ast_declarations_module_self_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *name, rbs_node_list_t *args) {
     rbs_ast_declarations_module_self_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_module_self_t);
 
@@ -428,7 +405,7 @@ rbs_ast_declarations_module_self_t *rbs_ast_declarations_module_self_new(rbs_all
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_declarations_module_alias_t *rbs_ast_declarations_module_alias_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *new_name, rbs_type_name_t *old_name, rbs_ast_comment_t *comment, rbs_node_list_t *annotations) {
     rbs_ast_declarations_module_alias_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_module_alias_t);
 
@@ -446,7 +423,7 @@ rbs_ast_declarations_module_alias_t *rbs_ast_declarations_module_alias_new(rbs_a
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_declarations_type_alias_t *rbs_ast_declarations_type_alias_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *name, rbs_node_list_t *type_params, rbs_node_t *type, rbs_node_list_t *annotations, rbs_ast_comment_t *comment) {
     rbs_ast_declarations_type_alias_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_type_alias_t);
 
@@ -465,7 +442,7 @@ rbs_ast_declarations_type_alias_t *rbs_ast_declarations_type_alias_new(rbs_alloc
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_directives_use_t *rbs_ast_directives_use_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_list_t *clauses) {
     rbs_ast_directives_use_t *instance = rbs_allocator_alloc(allocator, rbs_ast_directives_use_t);
 
@@ -480,7 +457,7 @@ rbs_ast_directives_use_t *rbs_ast_directives_use_new(rbs_allocator_t *allocator,
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_directives_use_single_clause_t *rbs_ast_directives_use_single_clause_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *type_name, rbs_ast_symbol_t *new_name) {
     rbs_ast_directives_use_single_clause_t *instance = rbs_allocator_alloc(allocator, rbs_ast_directives_use_single_clause_t);
 
@@ -496,7 +473,7 @@ rbs_ast_directives_use_single_clause_t *rbs_ast_directives_use_single_clause_new
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_directives_use_wildcard_clause_t *rbs_ast_directives_use_wildcard_clause_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_namespace_t *rbs_namespace) {
     rbs_ast_directives_use_wildcard_clause_t *instance = rbs_allocator_alloc(allocator, rbs_ast_directives_use_wildcard_clause_t);
 
@@ -511,7 +488,7 @@ rbs_ast_directives_use_wildcard_clause_t *rbs_ast_directives_use_wildcard_clause
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_integer_t *rbs_ast_integer_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_string_t string_representation) {
     rbs_ast_integer_t *instance = rbs_allocator_alloc(allocator, rbs_ast_integer_t);
 
@@ -526,7 +503,7 @@ rbs_ast_integer_t *rbs_ast_integer_new(rbs_allocator_t *allocator, rbs_location_
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_members_alias_t *rbs_ast_members_alias_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_ast_symbol_t *new_name, rbs_ast_symbol_t *old_name, rbs_keyword_t *kind, rbs_node_list_t *annotations, rbs_ast_comment_t *comment) {
     rbs_ast_members_alias_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_alias_t);
 
@@ -545,7 +522,7 @@ rbs_ast_members_alias_t *rbs_ast_members_alias_new(rbs_allocator_t *allocator, r
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_members_attr_accessor_t *rbs_ast_members_attr_accessor_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_node_t *ivar_name, rbs_keyword_t *kind, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_keyword_t *visibility) {
     rbs_ast_members_attr_accessor_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_attr_accessor_t);
 
@@ -566,7 +543,7 @@ rbs_ast_members_attr_accessor_t *rbs_ast_members_attr_accessor_new(rbs_allocator
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_members_attr_reader_t *rbs_ast_members_attr_reader_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_node_t *ivar_name, rbs_keyword_t *kind, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_keyword_t *visibility) {
     rbs_ast_members_attr_reader_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_attr_reader_t);
 
@@ -587,7 +564,7 @@ rbs_ast_members_attr_reader_t *rbs_ast_members_attr_reader_new(rbs_allocator_t *
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_members_attr_writer_t *rbs_ast_members_attr_writer_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_node_t *ivar_name, rbs_keyword_t *kind, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_keyword_t *visibility) {
     rbs_ast_members_attr_writer_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_attr_writer_t);
 
@@ -608,7 +585,7 @@ rbs_ast_members_attr_writer_t *rbs_ast_members_attr_writer_new(rbs_allocator_t *
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_members_class_instance_variable_t *rbs_ast_members_class_instance_variable_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_ast_comment_t *comment) {
     rbs_ast_members_class_instance_variable_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_class_instance_variable_t);
 
@@ -625,7 +602,7 @@ rbs_ast_members_class_instance_variable_t *rbs_ast_members_class_instance_variab
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_members_class_variable_t *rbs_ast_members_class_variable_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_ast_comment_t *comment) {
     rbs_ast_members_class_variable_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_class_variable_t);
 
@@ -642,7 +619,7 @@ rbs_ast_members_class_variable_t *rbs_ast_members_class_variable_new(rbs_allocat
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_members_extend_t *rbs_ast_members_extend_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_node_list_t *annotations, rbs_ast_comment_t *comment) {
     rbs_ast_members_extend_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_extend_t);
 
@@ -660,7 +637,7 @@ rbs_ast_members_extend_t *rbs_ast_members_extend_new(rbs_allocator_t *allocator,
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_members_include_t *rbs_ast_members_include_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_node_list_t *annotations, rbs_ast_comment_t *comment) {
     rbs_ast_members_include_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_include_t);
 
@@ -678,7 +655,7 @@ rbs_ast_members_include_t *rbs_ast_members_include_new(rbs_allocator_t *allocato
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_members_instance_variable_t *rbs_ast_members_instance_variable_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_ast_comment_t *comment) {
     rbs_ast_members_instance_variable_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_instance_variable_t);
 
@@ -695,7 +672,7 @@ rbs_ast_members_instance_variable_t *rbs_ast_members_instance_variable_new(rbs_a
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_members_method_definition_t *rbs_ast_members_method_definition_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_ast_symbol_t *name, rbs_keyword_t *kind, rbs_node_list_t *overloads, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, bool overloading, rbs_keyword_t *visibility) {
     rbs_ast_members_method_definition_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_method_definition_t);
 
@@ -716,7 +693,7 @@ rbs_ast_members_method_definition_t *rbs_ast_members_method_definition_new(rbs_a
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_members_method_definition_overload_t *rbs_ast_members_method_definition_overload_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_list_t *annotations, rbs_node_t *method_type) {
     rbs_ast_members_method_definition_overload_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_method_definition_overload_t);
 
@@ -732,7 +709,7 @@ rbs_ast_members_method_definition_overload_t *rbs_ast_members_method_definition_
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_members_prepend_t *rbs_ast_members_prepend_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_node_list_t *annotations, rbs_ast_comment_t *comment) {
     rbs_ast_members_prepend_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_prepend_t);
 
@@ -750,7 +727,7 @@ rbs_ast_members_prepend_t *rbs_ast_members_prepend_new(rbs_allocator_t *allocato
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_members_private_t *rbs_ast_members_private_new(rbs_allocator_t *allocator, rbs_location_t *location) {
     rbs_ast_members_private_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_private_t);
 
@@ -764,7 +741,7 @@ rbs_ast_members_private_t *rbs_ast_members_private_new(rbs_allocator_t *allocato
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_members_public_t *rbs_ast_members_public_new(rbs_allocator_t *allocator, rbs_location_t *location) {
     rbs_ast_members_public_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_public_t);
 
@@ -778,7 +755,7 @@ rbs_ast_members_public_t *rbs_ast_members_public_new(rbs_allocator_t *allocator,
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_string_t *rbs_ast_string_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_string_t string) {
     rbs_ast_string_t *instance = rbs_allocator_alloc(allocator, rbs_ast_string_t);
 
@@ -793,7 +770,7 @@ rbs_ast_string_t *rbs_ast_string_new(rbs_allocator_t *allocator, rbs_location_t 
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_ast_type_param_t *rbs_ast_type_param_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_ast_symbol_t *name, rbs_keyword_t *variance, rbs_node_t *upper_bound, rbs_node_t *default_type, bool unchecked) {
     rbs_ast_type_param_t *instance = rbs_allocator_alloc(allocator, rbs_ast_type_param_t);
 
@@ -812,7 +789,7 @@ rbs_ast_type_param_t *rbs_ast_type_param_new(rbs_allocator_t *allocator, rbs_loc
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_method_type_t *rbs_method_type_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_list_t *type_params, rbs_node_t *type, rbs_types_block_t *block) {
     rbs_method_type_t *instance = rbs_allocator_alloc(allocator, rbs_method_type_t);
 
@@ -829,7 +806,7 @@ rbs_method_type_t *rbs_method_type_new(rbs_allocator_t *allocator, rbs_location_
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_namespace_t *rbs_namespace_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_list_t *path, bool absolute) {
     rbs_namespace_t *instance = rbs_allocator_alloc(allocator, rbs_namespace_t);
 
@@ -845,7 +822,7 @@ rbs_namespace_t *rbs_namespace_new(rbs_allocator_t *allocator, rbs_location_t *l
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_signature_t *rbs_signature_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_list_t *directives, rbs_node_list_t *declarations) {
     rbs_signature_t *instance = rbs_allocator_alloc(allocator, rbs_signature_t);
 
@@ -861,7 +838,7 @@ rbs_signature_t *rbs_signature_new(rbs_allocator_t *allocator, rbs_location_t *l
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_type_name_t *rbs_type_name_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_namespace_t *rbs_namespace, rbs_ast_symbol_t *name) {
     rbs_type_name_t *instance = rbs_allocator_alloc(allocator, rbs_type_name_t);
 
@@ -877,7 +854,7 @@ rbs_type_name_t *rbs_type_name_new(rbs_allocator_t *allocator, rbs_location_t *l
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_alias_t *rbs_types_alias_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *name, rbs_node_list_t *args) {
     rbs_types_alias_t *instance = rbs_allocator_alloc(allocator, rbs_types_alias_t);
 
@@ -893,7 +870,7 @@ rbs_types_alias_t *rbs_types_alias_new(rbs_allocator_t *allocator, rbs_location_
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_bases_any_t *rbs_types_bases_any_new(rbs_allocator_t *allocator, rbs_location_t *location, bool todo) {
     rbs_types_bases_any_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_any_t);
 
@@ -908,7 +885,7 @@ rbs_types_bases_any_t *rbs_types_bases_any_new(rbs_allocator_t *allocator, rbs_l
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_bases_bool_t *rbs_types_bases_bool_new(rbs_allocator_t *allocator, rbs_location_t *location) {
     rbs_types_bases_bool_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_bool_t);
 
@@ -922,7 +899,7 @@ rbs_types_bases_bool_t *rbs_types_bases_bool_new(rbs_allocator_t *allocator, rbs
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_bases_bottom_t *rbs_types_bases_bottom_new(rbs_allocator_t *allocator, rbs_location_t *location) {
     rbs_types_bases_bottom_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_bottom_t);
 
@@ -936,7 +913,7 @@ rbs_types_bases_bottom_t *rbs_types_bases_bottom_new(rbs_allocator_t *allocator,
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_bases_class_t *rbs_types_bases_class_new(rbs_allocator_t *allocator, rbs_location_t *location) {
     rbs_types_bases_class_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_class_t);
 
@@ -950,7 +927,7 @@ rbs_types_bases_class_t *rbs_types_bases_class_new(rbs_allocator_t *allocator, r
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_bases_instance_t *rbs_types_bases_instance_new(rbs_allocator_t *allocator, rbs_location_t *location) {
     rbs_types_bases_instance_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_instance_t);
 
@@ -964,7 +941,7 @@ rbs_types_bases_instance_t *rbs_types_bases_instance_new(rbs_allocator_t *alloca
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_bases_nil_t *rbs_types_bases_nil_new(rbs_allocator_t *allocator, rbs_location_t *location) {
     rbs_types_bases_nil_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_nil_t);
 
@@ -978,7 +955,7 @@ rbs_types_bases_nil_t *rbs_types_bases_nil_new(rbs_allocator_t *allocator, rbs_l
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_bases_self_t *rbs_types_bases_self_new(rbs_allocator_t *allocator, rbs_location_t *location) {
     rbs_types_bases_self_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_self_t);
 
@@ -992,7 +969,7 @@ rbs_types_bases_self_t *rbs_types_bases_self_new(rbs_allocator_t *allocator, rbs
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_bases_top_t *rbs_types_bases_top_new(rbs_allocator_t *allocator, rbs_location_t *location) {
     rbs_types_bases_top_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_top_t);
 
@@ -1006,7 +983,7 @@ rbs_types_bases_top_t *rbs_types_bases_top_new(rbs_allocator_t *allocator, rbs_l
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_bases_void_t *rbs_types_bases_void_new(rbs_allocator_t *allocator, rbs_location_t *location) {
     rbs_types_bases_void_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_void_t);
 
@@ -1020,7 +997,7 @@ rbs_types_bases_void_t *rbs_types_bases_void_new(rbs_allocator_t *allocator, rbs
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_block_t *rbs_types_block_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_t *type, bool required, rbs_node_t *self_type) {
     rbs_types_block_t *instance = rbs_allocator_alloc(allocator, rbs_types_block_t);
 
@@ -1037,7 +1014,7 @@ rbs_types_block_t *rbs_types_block_new(rbs_allocator_t *allocator, rbs_location_
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_class_instance_t *rbs_types_class_instance_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *name, rbs_node_list_t *args) {
     rbs_types_class_instance_t *instance = rbs_allocator_alloc(allocator, rbs_types_class_instance_t);
 
@@ -1053,7 +1030,7 @@ rbs_types_class_instance_t *rbs_types_class_instance_new(rbs_allocator_t *alloca
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_class_singleton_t *rbs_types_class_singleton_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *name) {
     rbs_types_class_singleton_t *instance = rbs_allocator_alloc(allocator, rbs_types_class_singleton_t);
 
@@ -1068,7 +1045,7 @@ rbs_types_class_singleton_t *rbs_types_class_singleton_new(rbs_allocator_t *allo
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_function_t *rbs_types_function_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_list_t *required_positionals, rbs_node_list_t *optional_positionals, rbs_node_t *rest_positionals, rbs_node_list_t *trailing_positionals, rbs_hash_t *required_keywords, rbs_hash_t *optional_keywords, rbs_node_t *rest_keywords, rbs_node_t *return_type) {
     rbs_types_function_t *instance = rbs_allocator_alloc(allocator, rbs_types_function_t);
 
@@ -1090,7 +1067,7 @@ rbs_types_function_t *rbs_types_function_new(rbs_allocator_t *allocator, rbs_loc
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_function_param_t *rbs_types_function_param_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_t *type, rbs_ast_symbol_t *name) {
     rbs_types_function_param_t *instance = rbs_allocator_alloc(allocator, rbs_types_function_param_t);
 
@@ -1106,7 +1083,7 @@ rbs_types_function_param_t *rbs_types_function_param_new(rbs_allocator_t *alloca
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_interface_t *rbs_types_interface_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_type_name_t *name, rbs_node_list_t *args) {
     rbs_types_interface_t *instance = rbs_allocator_alloc(allocator, rbs_types_interface_t);
 
@@ -1122,7 +1099,7 @@ rbs_types_interface_t *rbs_types_interface_new(rbs_allocator_t *allocator, rbs_l
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_intersection_t *rbs_types_intersection_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_list_t *types) {
     rbs_types_intersection_t *instance = rbs_allocator_alloc(allocator, rbs_types_intersection_t);
 
@@ -1137,7 +1114,7 @@ rbs_types_intersection_t *rbs_types_intersection_new(rbs_allocator_t *allocator,
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_literal_t *rbs_types_literal_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_t *literal) {
     rbs_types_literal_t *instance = rbs_allocator_alloc(allocator, rbs_types_literal_t);
 
@@ -1152,7 +1129,7 @@ rbs_types_literal_t *rbs_types_literal_new(rbs_allocator_t *allocator, rbs_locat
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_optional_t *rbs_types_optional_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_t *type) {
     rbs_types_optional_t *instance = rbs_allocator_alloc(allocator, rbs_types_optional_t);
 
@@ -1167,7 +1144,7 @@ rbs_types_optional_t *rbs_types_optional_new(rbs_allocator_t *allocator, rbs_loc
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_proc_t *rbs_types_proc_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_t *type, rbs_types_block_t *block, rbs_node_t *self_type) {
     rbs_types_proc_t *instance = rbs_allocator_alloc(allocator, rbs_types_proc_t);
 
@@ -1184,7 +1161,7 @@ rbs_types_proc_t *rbs_types_proc_new(rbs_allocator_t *allocator, rbs_location_t 
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_record_t *rbs_types_record_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_hash_t *all_fields) {
     rbs_types_record_t *instance = rbs_allocator_alloc(allocator, rbs_types_record_t);
 
@@ -1199,7 +1176,7 @@ rbs_types_record_t *rbs_types_record_new(rbs_allocator_t *allocator, rbs_locatio
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_record_field_type_t *rbs_types_record_field_type_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_t *type, bool required) {
     rbs_types_record_field_type_t *instance = rbs_allocator_alloc(allocator, rbs_types_record_field_type_t);
 
@@ -1215,7 +1192,7 @@ rbs_types_record_field_type_t *rbs_types_record_field_type_new(rbs_allocator_t *
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_tuple_t *rbs_types_tuple_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_list_t *types) {
     rbs_types_tuple_t *instance = rbs_allocator_alloc(allocator, rbs_types_tuple_t);
 
@@ -1230,7 +1207,7 @@ rbs_types_tuple_t *rbs_types_tuple_new(rbs_allocator_t *allocator, rbs_location_
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_union_t *rbs_types_union_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_list_t *types) {
     rbs_types_union_t *instance = rbs_allocator_alloc(allocator, rbs_types_union_t);
 
@@ -1245,7 +1222,7 @@ rbs_types_union_t *rbs_types_union_new(rbs_allocator_t *allocator, rbs_location_
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_untyped_function_t *rbs_types_untyped_function_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_node_t *return_type) {
     rbs_types_untyped_function_t *instance = rbs_allocator_alloc(allocator, rbs_types_untyped_function_t);
 
@@ -1260,7 +1237,7 @@ rbs_types_untyped_function_t *rbs_types_untyped_function_new(rbs_allocator_t *al
 
     return instance;
 }
-#line 176 "prism/templates/src/ast.c.erb"
+#line 153 "prism/templates/src/ast.c.erb"
 rbs_types_variable_t *rbs_types_variable_new(rbs_allocator_t *allocator, rbs_location_t *location, rbs_ast_symbol_t *name) {
     rbs_types_variable_t *instance = rbs_allocator_alloc(allocator, rbs_types_variable_t);
 
@@ -1274,704 +1251,4 @@ rbs_types_variable_t *rbs_types_variable_new(rbs_allocator_t *allocator, rbs_loc
     };
 
     return instance;
-}
-
-#line 198 "prism/templates/src/ast.c.erb"
-void rbs_node_destroy(rbs_node_t *any_node) {
-    switch (any_node->type) {
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_ANNOTATION: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_BOOL: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_COMMENT: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_DECLARATIONS_CLASS: {
-        rbs_ast_declarations_class_t *node = (rbs_ast_declarations_class_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        rbs_node_list_free(node->type_params);
-        if (node->super_class != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->super_class);
-        }
-        rbs_node_list_free(node->members);
-        rbs_node_list_free(node->annotations);
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_DECLARATIONS_CLASS_SUPER: {
-        rbs_ast_declarations_class_super_t *node = (rbs_ast_declarations_class_super_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        rbs_node_list_free(node->args);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_DECLARATIONS_CLASS_ALIAS: {
-        rbs_ast_declarations_class_alias_t *node = (rbs_ast_declarations_class_alias_t *)any_node;
-
-        if (node->new_name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->new_name);
-        }
-        if (node->old_name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->old_name);
-        }
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        rbs_node_list_free(node->annotations);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_DECLARATIONS_CONSTANT: {
-        rbs_ast_declarations_constant_t *node = (rbs_ast_declarations_constant_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        rbs_node_list_free(node->annotations);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_DECLARATIONS_GLOBAL: {
-        rbs_ast_declarations_global_t *node = (rbs_ast_declarations_global_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        rbs_node_list_free(node->annotations);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_DECLARATIONS_INTERFACE: {
-        rbs_ast_declarations_interface_t *node = (rbs_ast_declarations_interface_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        rbs_node_list_free(node->type_params);
-        rbs_node_list_free(node->members);
-        rbs_node_list_free(node->annotations);
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_DECLARATIONS_MODULE: {
-        rbs_ast_declarations_module_t *node = (rbs_ast_declarations_module_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        rbs_node_list_free(node->type_params);
-        rbs_node_list_free(node->self_types);
-        rbs_node_list_free(node->members);
-        rbs_node_list_free(node->annotations);
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_DECLARATIONS_MODULE_SELF: {
-        rbs_ast_declarations_module_self_t *node = (rbs_ast_declarations_module_self_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        rbs_node_list_free(node->args);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_DECLARATIONS_MODULE_ALIAS: {
-        rbs_ast_declarations_module_alias_t *node = (rbs_ast_declarations_module_alias_t *)any_node;
-
-        if (node->new_name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->new_name);
-        }
-        if (node->old_name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->old_name);
-        }
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        rbs_node_list_free(node->annotations);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_DECLARATIONS_TYPE_ALIAS: {
-        rbs_ast_declarations_type_alias_t *node = (rbs_ast_declarations_type_alias_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        rbs_node_list_free(node->type_params);
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        rbs_node_list_free(node->annotations);
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_DIRECTIVES_USE: {
-        rbs_ast_directives_use_t *node = (rbs_ast_directives_use_t *)any_node;
-
-        rbs_node_list_free(node->clauses);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_DIRECTIVES_USE_SINGLE_CLAUSE: {
-        rbs_ast_directives_use_single_clause_t *node = (rbs_ast_directives_use_single_clause_t *)any_node;
-
-        if (node->type_name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type_name);
-        }
-        if (node->new_name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->new_name);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_DIRECTIVES_USE_WILDCARD_CLAUSE: {
-        rbs_ast_directives_use_wildcard_clause_t *node = (rbs_ast_directives_use_wildcard_clause_t *)any_node;
-
-        if (node->rbs_namespace != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->rbs_namespace);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_INTEGER: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_MEMBERS_ALIAS: {
-        rbs_ast_members_alias_t *node = (rbs_ast_members_alias_t *)any_node;
-
-        if (node->new_name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->new_name);
-        }
-        if (node->old_name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->old_name);
-        }
-        if (node->kind != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->kind);
-        }
-        rbs_node_list_free(node->annotations);
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_MEMBERS_ATTR_ACCESSOR: {
-        rbs_ast_members_attr_accessor_t *node = (rbs_ast_members_attr_accessor_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        if (node->ivar_name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->ivar_name);
-        }
-        if (node->kind != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->kind);
-        }
-        rbs_node_list_free(node->annotations);
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        if (node->visibility != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->visibility);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_MEMBERS_ATTR_READER: {
-        rbs_ast_members_attr_reader_t *node = (rbs_ast_members_attr_reader_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        if (node->ivar_name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->ivar_name);
-        }
-        if (node->kind != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->kind);
-        }
-        rbs_node_list_free(node->annotations);
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        if (node->visibility != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->visibility);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_MEMBERS_ATTR_WRITER: {
-        rbs_ast_members_attr_writer_t *node = (rbs_ast_members_attr_writer_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        if (node->ivar_name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->ivar_name);
-        }
-        if (node->kind != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->kind);
-        }
-        rbs_node_list_free(node->annotations);
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        if (node->visibility != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->visibility);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_MEMBERS_CLASS_INSTANCE_VARIABLE: {
-        rbs_ast_members_class_instance_variable_t *node = (rbs_ast_members_class_instance_variable_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_MEMBERS_CLASS_VARIABLE: {
-        rbs_ast_members_class_variable_t *node = (rbs_ast_members_class_variable_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_MEMBERS_EXTEND: {
-        rbs_ast_members_extend_t *node = (rbs_ast_members_extend_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        rbs_node_list_free(node->args);
-        rbs_node_list_free(node->annotations);
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_MEMBERS_INCLUDE: {
-        rbs_ast_members_include_t *node = (rbs_ast_members_include_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        rbs_node_list_free(node->args);
-        rbs_node_list_free(node->annotations);
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_MEMBERS_INSTANCE_VARIABLE: {
-        rbs_ast_members_instance_variable_t *node = (rbs_ast_members_instance_variable_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_MEMBERS_METHOD_DEFINITION: {
-        rbs_ast_members_method_definition_t *node = (rbs_ast_members_method_definition_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        if (node->kind != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->kind);
-        }
-        rbs_node_list_free(node->overloads);
-        rbs_node_list_free(node->annotations);
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        // overloading is a bool, so we don't need to free it.
-        if (node->visibility != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->visibility);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_MEMBERS_METHOD_DEFINITION_OVERLOAD: {
-        rbs_ast_members_method_definition_overload_t *node = (rbs_ast_members_method_definition_overload_t *)any_node;
-
-        rbs_node_list_free(node->annotations);
-        if (node->method_type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->method_type);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_MEMBERS_PREPEND: {
-        rbs_ast_members_prepend_t *node = (rbs_ast_members_prepend_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        rbs_node_list_free(node->args);
-        rbs_node_list_free(node->annotations);
-        if (node->comment != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->comment);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_MEMBERS_PRIVATE: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_MEMBERS_PUBLIC: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_STRING: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_AST_TYPE_PARAM: {
-        rbs_ast_type_param_t *node = (rbs_ast_type_param_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        if (node->variance != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->variance);
-        }
-        if (node->upper_bound != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->upper_bound);
-        }
-        if (node->default_type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->default_type);
-        }
-        // unchecked is a bool, so we don't need to free it.
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_METHOD_TYPE: {
-        rbs_method_type_t *node = (rbs_method_type_t *)any_node;
-
-        rbs_node_list_free(node->type_params);
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        if (node->block != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->block);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_NAMESPACE: {
-        rbs_namespace_t *node = (rbs_namespace_t *)any_node;
-
-        rbs_node_list_free(node->path);
-        // absolute is a bool, so we don't need to free it.
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_SIGNATURE: {
-        rbs_signature_t *node = (rbs_signature_t *)any_node;
-
-        rbs_node_list_free(node->directives);
-        rbs_node_list_free(node->declarations);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPE_NAME: {
-        rbs_type_name_t *node = (rbs_type_name_t *)any_node;
-
-        if (node->rbs_namespace != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->rbs_namespace);
-        }
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_ALIAS: {
-        rbs_types_alias_t *node = (rbs_types_alias_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        rbs_node_list_free(node->args);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_BASES_ANY: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_BASES_BOOL: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_BASES_BOTTOM: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_BASES_CLASS: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_BASES_INSTANCE: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_BASES_NIL: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_BASES_SELF: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_BASES_TOP: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_BASES_VOID: {
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_BLOCK: {
-        rbs_types_block_t *node = (rbs_types_block_t *)any_node;
-
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        // required is a bool, so we don't need to free it.
-        if (node->self_type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->self_type);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_CLASS_INSTANCE: {
-        rbs_types_class_instance_t *node = (rbs_types_class_instance_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        rbs_node_list_free(node->args);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_CLASS_SINGLETON: {
-        rbs_types_class_singleton_t *node = (rbs_types_class_singleton_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_FUNCTION: {
-        rbs_types_function_t *node = (rbs_types_function_t *)any_node;
-
-        rbs_node_list_free(node->required_positionals);
-        rbs_node_list_free(node->optional_positionals);
-        if (node->rest_positionals != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->rest_positionals);
-        }
-        rbs_node_list_free(node->trailing_positionals);
-        rbs_hash_free(node->required_keywords);
-        rbs_hash_free(node->optional_keywords);
-        if (node->rest_keywords != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->rest_keywords);
-        }
-        if (node->return_type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->return_type);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_FUNCTION_PARAM: {
-        rbs_types_function_param_t *node = (rbs_types_function_param_t *)any_node;
-
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_INTERFACE: {
-        rbs_types_interface_t *node = (rbs_types_interface_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        rbs_node_list_free(node->args);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_INTERSECTION: {
-        rbs_types_intersection_t *node = (rbs_types_intersection_t *)any_node;
-
-        rbs_node_list_free(node->types);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_LITERAL: {
-        rbs_types_literal_t *node = (rbs_types_literal_t *)any_node;
-
-        if (node->literal != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->literal);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_OPTIONAL: {
-        rbs_types_optional_t *node = (rbs_types_optional_t *)any_node;
-
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_PROC: {
-        rbs_types_proc_t *node = (rbs_types_proc_t *)any_node;
-
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        if (node->block != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->block);
-        }
-        if (node->self_type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->self_type);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_RECORD: {
-        rbs_types_record_t *node = (rbs_types_record_t *)any_node;
-
-        rbs_hash_free(node->all_fields);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_RECORD_FIELD_TYPE: {
-        rbs_types_record_field_type_t *node = (rbs_types_record_field_type_t *)any_node;
-
-        if (node->type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->type);
-        }
-        // required is a bool, so we don't need to free it.
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_TUPLE: {
-        rbs_types_tuple_t *node = (rbs_types_tuple_t *)any_node;
-
-        rbs_node_list_free(node->types);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_UNION: {
-        rbs_types_union_t *node = (rbs_types_union_t *)any_node;
-
-        rbs_node_list_free(node->types);
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_UNTYPED_FUNCTION: {
-        rbs_types_untyped_function_t *node = (rbs_types_untyped_function_t *)any_node;
-
-        if (node->return_type != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->return_type);
-        }
-        break;
-    }
-#line 202 "prism/templates/src/ast.c.erb"
-    case RBS_TYPES_VARIABLE: {
-        rbs_types_variable_t *node = (rbs_types_variable_t *)any_node;
-
-        if (node->name != NULL) {
-            rbs_node_destroy((rbs_node_t *) node->name);
-        }
-        break;
-    }
-    case RBS_KEYWORD:
-    case RBS_AST_SYMBOL: {
-        // TODO: Delete symbol from constant pool? Or just free the whole constant pool?
-        break;
-    }
-    }
-
-    // `any_node` will be freed automatically when the arena is freed.
 }

--- a/templates/include/rbs/ast.h.erb
+++ b/templates/include/rbs/ast.h.erb
@@ -98,6 +98,4 @@ rbs_ast_symbol_t *rbs_ast_symbol_new(rbs_allocator_t *, rbs_location_t *, rbs_co
 <%= node.c_type_name %> *<%= node.c_constructor_function_name %>(<%= node.constructor_params.map(&:parameter_decl).join(", ") %>);
 <%- end -%>
 
-void rbs_node_destroy(rbs_node_t *any_node);
-
 #endif

--- a/templates/src/ast.c.erb
+++ b/templates/src/ast.c.erb
@@ -28,17 +28,6 @@ rbs_node_list_t* rbs_node_list_new(rbs_allocator_t *allocator) {
     return list;
 }
 
-void rbs_node_list_free(rbs_node_list_t *list) {
-    rbs_node_list_node_t *current = list->head;
-    while (current != NULL) {
-        rbs_node_list_node_t *next = current->next;
-        rbs_node_destroy(current->node);
-        // `current` is owned by the arena, so it will be freed automatically when the arena is freed.
-        current = next;
-    }
-    // `list` is owned by the arena, so it will be freed automatically when the arena is freed.
-}
-
 void rbs_node_list_append(rbs_node_list_t *list, rbs_node_t *node) {
     rbs_node_list_node_t *new_node = rbs_allocator_alloc(list->allocator, rbs_node_list_node_t);
     *new_node = (rbs_node_list_node_t) {
@@ -69,18 +58,6 @@ rbs_hash_t* rbs_hash_new(rbs_allocator_t *allocator) {
     };
 
     return hash;
-}
-
-void rbs_hash_free(rbs_hash_t *hash) {
-    rbs_hash_node_t *current = hash->head;
-    while (current != NULL) {
-        rbs_hash_node_t *next = current->next;
-        rbs_node_destroy(current->key);
-        rbs_node_destroy(current->value);
-        // `current` is owned by the arena, so it will be freed automatically when the arena is freed.
-        current = next;
-    }
-    // `hash` is owned by the arena, so it will be freed automatically when the arena is freed.
 }
 
 bool rbs_node_equal(rbs_node_t *lhs, rbs_node_t *rhs) {
@@ -193,40 +170,3 @@ rbs_ast_symbol_t *rbs_ast_symbol_new(rbs_allocator_t *allocator, rbs_location_t 
     return instance;
 }
 <%- end -%>
-
-#line <%= __LINE__ + 1 %> "prism/templates/src/<%= File.basename(__FILE__) %>"
-void rbs_node_destroy(rbs_node_t *any_node) {
-    switch (any_node->type) {
-    <%- nodes.each do |node| -%>
-#line <%= __LINE__ + 1 %> "prism/templates/src/<%= File.basename(__FILE__) %>"
-    case <%= node.c_type_enum_name %>: {
-        <%- if node.has_children_to_free? -%>
-        <%= node.c_type_name %> *node = (<%= node.c_type_name %> *)any_node;
-
-        <%- node.fields.each do |field| -%>
-        <%- case field.c_type -%>
-        <%- when "rbs_node_list" -%>
-        rbs_node_list_free(node-><%= field.c_name %>);
-        <%- when "rbs_hash" -%>
-        rbs_hash_free(node-><%= field.c_name %>);
-        <%- when "bool" -%>
-        // <%= field.c_name %> is a bool, so we don't need to free it.
-        <%- else -%>
-        if (node-><%= field.c_name %> != NULL) {
-            rbs_node_destroy((rbs_node_t *) node-><%= field.c_name %>);
-        }
-        <%- end -%>
-        <%- end -%>
-        <%- end -%>
-        break;
-    }
-    <%- end -%>
-    case RBS_KEYWORD:
-    case RBS_AST_SYMBOL: {
-        // TODO: Delete symbol from constant pool? Or just free the whole constant pool?
-        break;
-    }
-    }
-
-    // `any_node` will be freed automatically when the arena is freed.
-}

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -53,10 +53,6 @@ module RBS
           @c_type.include?("_decl_") ||
           @c_type.include?("_types_")
       end
-
-      def needs_to_be_freed?
-        !["VALUE", "bool", "rbs_string"].include?(@c_type)
-      end
     end
 
     class Type
@@ -129,10 +125,6 @@ module RBS
 
       def expose_location?
         @expose_location
-      end
-
-      def has_children_to_free?
-        @fields.any?(&:needs_to_be_freed?)
       end
 
       # Convert CamelCase to snake_case


### PR DESCRIPTION
`rbs_node_destroy`, `rbs_hash_free`, `rbs_node_list_free` are only calling each other recursively without any real freeing logic.

This is the result of previous efforts to allocate all nodes on the arena. So we don't need these functions anymore.

Discovered while working on #41 